### PR TITLE
[release/9.0] Add System.Security.Cryptography.Xml 8.0.4

### DIFF
--- a/eng/Build.props
+++ b/eng/Build.props
@@ -78,6 +78,8 @@
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Extensions.Logging.Abstractions.6.0.0.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Diagnostics.DiagnosticSource.6.0.2.csproj" />
     <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\Microsoft.Bcl.TimeProvider.8.0.1.csproj" />
+
+    <DependencyPackageProjects Include="$(RepoRoot)src\referencePackages\src\**\System.Security.Cryptography.Xml.8.0.4.csproj" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(BuildDependencyPackageProjects)' == 'true'">

--- a/src/referencePackages/src/system.security.cryptography.xml/8.0.4/System.Security.Cryptography.Xml.8.0.4.csproj
+++ b/src/referencePackages/src/system.security.cryptography.xml/8.0.4/System.Security.Cryptography.Xml.8.0.4.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net6.0;net7.0;net8.0;netstandard2.0</TargetFrameworks>
+    <AssemblyName>System.Security.Cryptography.Xml</AssemblyName>
+    <StrongNameKeyId>Open</StrongNameKeyId>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
+    <ProjectReference Include="../../system.security.cryptography.pkcs/8.0.1/System.Security.Cryptography.Pkcs.8.0.1.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net7.0'">
+    <ProjectReference Include="../../system.security.cryptography.pkcs/8.0.1/System.Security.Cryptography.Pkcs.8.0.1.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
+    <ProjectReference Include="../../system.security.cryptography.pkcs/8.0.1/System.Security.Cryptography.Pkcs.8.0.1.csproj" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <ProjectReference Include="../../system.security.cryptography.pkcs/8.0.1/System.Security.Cryptography.Pkcs.8.0.1.csproj" />
+    <ProjectReference Include="../../system.memory/4.5.5/System.Memory.4.5.5.csproj" />
+    <ProjectReference Include="../../system.security.accesscontrol/6.0.0/System.Security.AccessControl.6.0.0.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/referencePackages/src/system.security.cryptography.xml/8.0.4/lib/net6.0/System.Security.Cryptography.Xml.cs
+++ b/src/referencePackages/src/system.security.cryptography.xml/8.0.4/lib/net6.0/System.Security.Cryptography.Xml.cs
@@ -1,0 +1,936 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v6.0", FrameworkDisplayName = ".NET 6.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Security.Cryptography.Xml")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides classes to support the creation and validation of XML digital signatures. The classes in this namespace implement the World Wide Web Consortium Recommendation, \"XML-Signature Syntax and Processing\", described at http://www.w3.org/TR/xmldsig-core/.\r\n\r\nCommonly Used Types:\r\nSystem.Security.Cryptography.Xml.CipherData\r\nSystem.Security.Cryptography.Xml.CipherReference\r\nSystem.Security.Cryptography.Xml.DataObject\r\nSystem.Security.Cryptography.Xml.DataReference\r\nSystem.Security.Cryptography.Xml.DSAKeyValue\r\nSystem.Security.Cryptography.Xml.EncryptedData\r\nSystem.Security.Cryptography.Xml.EncryptedKey\r\nSystem.Security.Cryptography.Xml.EncryptedReference\r\nSystem.Security.Cryptography.Xml.EncryptedType\r\nSystem.Security.Cryptography.Xml.EncryptedXml\r\nSystem.Security.Cryptography.Xml.EncryptionMethod\r\nSystem.Security.Cryptography.Xml.EncryptionProperty\r\nSystem.Security.Cryptography.Xml.EncryptionPropertyCollection\r\nSystem.Security.Cryptography.Xml.KeyInfo\r\nSystem.Security.Cryptography.Xml.KeyInfoClause\r\nSystem.Security.Cryptography.Xml.KeyInfoEncryptedKey\r\nSystem.Security.Cryptography.Xml.KeyInfoName\r\nSystem.Security.Cryptography.Xml.KeyInfoNode\r\nSystem.Security.Cryptography.Xml.KeyInfoRetrievalMethod\r\nSystem.Security.Cryptography.Xml.KeyInfoX509Data\r\nSystem.Security.Cryptography.Xml.KeyReference\r\nSystem.Security.Cryptography.Xml.Reference\r\nSystem.Security.Cryptography.Xml.ReferenceList\r\nSystem.Security.Cryptography.Xml.RSAKeyValue\r\nSystem.Security.Cryptography.Xml.Signature\r\nSystem.Security.Cryptography.Xml.SignedInfo\r\nSystem.Security.Cryptography.Xml.SignedXml\r\nSystem.Security.Cryptography.Xml.Transform\r\nSystem.Security.Cryptography.Xml.TransformChain\r\nSystem.Security.Cryptography.Xml.XmlDecryptionTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigBase64Transform\r\nSystem.Security.Cryptography.Xml.XmlDsigC14NTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigC14NWithCommentsTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigEnvelopedSignatureTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigExcC14NTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigExcC14NWithCommentsTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigXPathTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigXsltTransform\r\nSystem.Security.Cryptography.Xml.XmlLicenseTransform")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.2926.32403")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.29+18fd75c847399745c43b5970fec840ba71064e80")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Security.Cryptography.Xml")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Security.Cryptography.Xml
+{
+    public sealed partial class CipherData
+    {
+        public CipherData() { }
+
+        public CipherData(byte[] cipherValue) { }
+
+        public CipherData(CipherReference cipherReference) { }
+
+        public CipherReference? CipherReference { get { throw null; } set { } }
+
+        public byte[]? CipherValue { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class CipherReference : EncryptedReference
+    {
+        public CipherReference() { }
+
+        public CipherReference(string uri, TransformChain transformChain) { }
+
+        public CipherReference(string uri) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class CryptoSignedXmlRecursionException : System.Xml.XmlException
+    {
+        public CryptoSignedXmlRecursionException() { }
+
+        protected CryptoSignedXmlRecursionException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+
+        public CryptoSignedXmlRecursionException(string message, Exception inner) { }
+
+        public CryptoSignedXmlRecursionException(string message) { }
+    }
+
+    public partial class DataObject
+    {
+        public DataObject() { }
+
+        public DataObject(string id, string mimeType, string encoding, System.Xml.XmlElement data) { }
+
+        public System.Xml.XmlNodeList Data { get { throw null; } set { } }
+
+        public string? Encoding { get { throw null; } set { } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public string? MimeType { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class DataReference : EncryptedReference
+    {
+        public DataReference() { }
+
+        public DataReference(string uri, TransformChain transformChain) { }
+
+        public DataReference(string uri) { }
+    }
+
+    public partial class DSAKeyValue : KeyInfoClause
+    {
+        [Runtime.Versioning.UnsupportedOSPlatform("ios")]
+        [Runtime.Versioning.UnsupportedOSPlatform("tvos")]
+        public DSAKeyValue() { }
+
+        public DSAKeyValue(DSA key) { }
+
+        public DSA Key { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptedData : EncryptedType
+    {
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptedKey : EncryptedType
+    {
+        public string? CarriedKeyName { get { throw null; } set { } }
+
+        public string Recipient { get { throw null; } set { } }
+
+        public ReferenceList ReferenceList { get { throw null; } }
+
+        public void AddReference(DataReference dataReference) { }
+
+        public void AddReference(KeyReference keyReference) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class EncryptedReference
+    {
+        protected EncryptedReference() { }
+
+        protected EncryptedReference(string uri, TransformChain transformChain) { }
+
+        protected EncryptedReference(string uri) { }
+
+        [Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "_cachedXml")]
+        protected internal bool CacheValid { get { throw null; } }
+
+        protected string? ReferenceType { get { throw null; } set { } }
+
+        public TransformChain TransformChain { get { throw null; } set { } }
+
+        public string Uri { get { throw null; } set { } }
+
+        public void AddTransform(Transform transform) { }
+
+        public virtual System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public virtual void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class EncryptedType
+    {
+        public virtual CipherData CipherData { get { throw null; } set { } }
+
+        public virtual string? Encoding { get { throw null; } set { } }
+
+        public virtual EncryptionMethod? EncryptionMethod { get { throw null; } set { } }
+
+        public virtual EncryptionPropertyCollection EncryptionProperties { get { throw null; } }
+
+        public virtual string? Id { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public virtual string? MimeType { get { throw null; } set { } }
+
+        public virtual string? Type { get { throw null; } set { } }
+
+        public void AddProperty(EncryptionProperty ep) { }
+
+        public abstract System.Xml.XmlElement GetXml();
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public abstract void LoadXml(System.Xml.XmlElement value);
+    }
+
+    public partial class EncryptedXml
+    {
+        public const string XmlEncAES128KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes128";
+        public const string XmlEncAES128Url = "http://www.w3.org/2001/04/xmlenc#aes128-cbc";
+        public const string XmlEncAES192KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes192";
+        public const string XmlEncAES192Url = "http://www.w3.org/2001/04/xmlenc#aes192-cbc";
+        public const string XmlEncAES256KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes256";
+        public const string XmlEncAES256Url = "http://www.w3.org/2001/04/xmlenc#aes256-cbc";
+        public const string XmlEncDESUrl = "http://www.w3.org/2001/04/xmlenc#des-cbc";
+        public const string XmlEncElementContentUrl = "http://www.w3.org/2001/04/xmlenc#Content";
+        public const string XmlEncElementUrl = "http://www.w3.org/2001/04/xmlenc#Element";
+        public const string XmlEncEncryptedKeyUrl = "http://www.w3.org/2001/04/xmlenc#EncryptedKey";
+        public const string XmlEncNamespaceUrl = "http://www.w3.org/2001/04/xmlenc#";
+        public const string XmlEncRSA15Url = "http://www.w3.org/2001/04/xmlenc#rsa-1_5";
+        public const string XmlEncRSAOAEPUrl = "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p";
+        public const string XmlEncSHA256Url = "http://www.w3.org/2001/04/xmlenc#sha256";
+        public const string XmlEncSHA512Url = "http://www.w3.org/2001/04/xmlenc#sha512";
+        public const string XmlEncTripleDESKeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-tripledes";
+        public const string XmlEncTripleDESUrl = "http://www.w3.org/2001/04/xmlenc#tripledes-cbc";
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public EncryptedXml() { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public EncryptedXml(System.Xml.XmlDocument document, Policy.Evidence? evidence) { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public EncryptedXml(System.Xml.XmlDocument document) { }
+
+        public Policy.Evidence? DocumentEvidence { get { throw null; } set { } }
+
+        public Text.Encoding Encoding { get { throw null; } set { } }
+
+        public CipherMode Mode { get { throw null; } set { } }
+
+        public PaddingMode Padding { get { throw null; } set { } }
+
+        public string Recipient { get { throw null; } set { } }
+
+        public System.Xml.XmlResolver? Resolver { get { throw null; } set { } }
+
+        public int XmlDSigSearchDepth { get { throw null; } set { } }
+
+        public void AddKeyNameMapping(string keyName, object keyObject) { }
+
+        public void ClearKeyNameMappings() { }
+
+        public byte[] DecryptData(EncryptedData encryptedData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public void DecryptDocument() { }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public virtual byte[]? DecryptEncryptedKey(EncryptedKey encryptedKey) { throw null; }
+
+        public static byte[] DecryptKey(byte[] keyData, RSA rsa, bool useOAEP) { throw null; }
+
+        public static byte[] DecryptKey(byte[] keyData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public EncryptedData Encrypt(System.Xml.XmlElement inputElement, X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public EncryptedData Encrypt(System.Xml.XmlElement inputElement, string keyName) { throw null; }
+
+        public byte[] EncryptData(byte[] plaintext, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        public byte[] EncryptData(System.Xml.XmlElement inputElement, SymmetricAlgorithm symmetricAlgorithm, bool content) { throw null; }
+
+        public static byte[] EncryptKey(byte[] keyData, RSA rsa, bool useOAEP) { throw null; }
+
+        public static byte[] EncryptKey(byte[] keyData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        public virtual byte[] GetDecryptionIV(EncryptedData encryptedData, string? symmetricAlgorithmUri) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public virtual SymmetricAlgorithm? GetDecryptionKey(EncryptedData encryptedData, string? symmetricAlgorithmUri) { throw null; }
+
+        public virtual System.Xml.XmlElement? GetIdElement(System.Xml.XmlDocument document, string idValue) { throw null; }
+
+        public void ReplaceData(System.Xml.XmlElement inputElement, byte[] decryptedData) { }
+
+        public static void ReplaceElement(System.Xml.XmlElement inputElement, EncryptedData encryptedData, bool content) { }
+    }
+
+    public partial class EncryptionMethod
+    {
+        public EncryptionMethod() { }
+
+        public EncryptionMethod(string? algorithm) { }
+
+        public string? KeyAlgorithm { get { throw null; } set { } }
+
+        public int KeySize { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptionProperty
+    {
+        public EncryptionProperty() { }
+
+        public EncryptionProperty(System.Xml.XmlElement elementProperty) { }
+
+        public string? Id { get { throw null; } }
+
+        public System.Xml.XmlElement? PropertyElement { get { throw null; } set { } }
+
+        public string? Target { get { throw null; } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptionPropertyCollection : Collections.IList, Collections.ICollection, Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public bool IsFixedSize { get { throw null; } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        [System.Runtime.CompilerServices.IndexerName("ItemOf")]
+        public EncryptionProperty this[int index] { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        object? Collections.IList.this[int index] { get { throw null; } set { } }
+
+        public int Add(EncryptionProperty value) { throw null; }
+
+        public void Clear() { }
+
+        public bool Contains(EncryptionProperty value) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(EncryptionProperty[] array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public int IndexOf(EncryptionProperty value) { throw null; }
+
+        public void Insert(int index, EncryptionProperty value) { }
+
+        public EncryptionProperty Item(int index) { throw null; }
+
+        public void Remove(EncryptionProperty value) { }
+
+        public void RemoveAt(int index) { }
+
+        int Collections.IList.Add(object value) { throw null; }
+
+        bool Collections.IList.Contains(object value) { throw null; }
+
+        int Collections.IList.IndexOf(object value) { throw null; }
+
+        void Collections.IList.Insert(int index, object value) { }
+
+        void Collections.IList.Remove(object value) { }
+    }
+
+    public partial interface IRelDecryptor
+    {
+        IO.Stream Decrypt(EncryptionMethod encryptionMethod, KeyInfo keyInfo, IO.Stream toDecrypt);
+    }
+
+    public partial class KeyInfo : Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public void AddClause(KeyInfoClause clause) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public Collections.IEnumerator GetEnumerator(Type requestedObjectType) { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class KeyInfoClause
+    {
+        public abstract System.Xml.XmlElement GetXml();
+        public abstract void LoadXml(System.Xml.XmlElement element);
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class KeyInfoEncryptedKey : KeyInfoClause
+    {
+        public KeyInfoEncryptedKey() { }
+
+        public KeyInfoEncryptedKey(EncryptedKey encryptedKey) { }
+
+        public EncryptedKey? EncryptedKey { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoName : KeyInfoClause
+    {
+        public KeyInfoName() { }
+
+        public KeyInfoName(string? keyName) { }
+
+        public string? Value { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoNode : KeyInfoClause
+    {
+        public KeyInfoNode() { }
+
+        public KeyInfoNode(System.Xml.XmlElement node) { }
+
+        public System.Xml.XmlElement? Value { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoRetrievalMethod : KeyInfoClause
+    {
+        public KeyInfoRetrievalMethod() { }
+
+        public KeyInfoRetrievalMethod(string strUri, string typeName) { }
+
+        public KeyInfoRetrievalMethod(string? strUri) { }
+
+        public string? Type { get { throw null; } set { } }
+
+        public string? Uri { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoX509Data : KeyInfoClause
+    {
+        public KeyInfoX509Data() { }
+
+        public KeyInfoX509Data(byte[] rgbCert) { }
+
+        public KeyInfoX509Data(X509Certificates.X509Certificate cert, X509Certificates.X509IncludeOption includeOption) { }
+
+        public KeyInfoX509Data(X509Certificates.X509Certificate cert) { }
+
+        public Collections.ArrayList? Certificates { get { throw null; } }
+
+        public byte[]? CRL { get { throw null; } set { } }
+
+        public Collections.ArrayList? IssuerSerials { get { throw null; } }
+
+        public Collections.ArrayList? SubjectKeyIds { get { throw null; } }
+
+        public Collections.ArrayList? SubjectNames { get { throw null; } }
+
+        public void AddCertificate(X509Certificates.X509Certificate certificate) { }
+
+        public void AddIssuerSerial(string issuerName, string serialNumber) { }
+
+        public void AddSubjectKeyId(byte[] subjectKeyId) { }
+
+        public void AddSubjectKeyId(string subjectKeyId) { }
+
+        public void AddSubjectName(string subjectName) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement element) { }
+    }
+
+    public sealed partial class KeyReference : EncryptedReference
+    {
+        public KeyReference() { }
+
+        public KeyReference(string uri, TransformChain transformChain) { }
+
+        public KeyReference(string uri) { }
+    }
+
+    public partial class Reference
+    {
+        public Reference() { }
+
+        public Reference(IO.Stream stream) { }
+
+        public Reference(string? uri) { }
+
+        public string DigestMethod { get { throw null; } set { } }
+
+        public byte[]? DigestValue { get { throw null; } set { } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public TransformChain TransformChain { get { throw null; } set { } }
+
+        public string? Type { get { throw null; } set { } }
+
+        public string? Uri { get { throw null; } set { } }
+
+        public void AddTransform(Transform transform) { }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class ReferenceList : Collections.IList, Collections.ICollection, Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        [System.Runtime.CompilerServices.IndexerName("ItemOf")]
+        public EncryptedReference this[int index] { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        bool Collections.IList.IsFixedSize { get { throw null; } }
+
+        bool Collections.IList.IsReadOnly { get { throw null; } }
+
+        object? Collections.IList.this[int index] { get { throw null; } set { } }
+
+        public int Add(object? value) { throw null; }
+
+        public void Clear() { }
+
+        public bool Contains(object? value) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public int IndexOf(object? value) { throw null; }
+
+        public void Insert(int index, object? value) { }
+
+        public EncryptedReference? Item(int index) { throw null; }
+
+        public void Remove(object? value) { }
+
+        public void RemoveAt(int index) { }
+    }
+
+    public partial class RSAKeyValue : KeyInfoClause
+    {
+        public RSAKeyValue() { }
+
+        public RSAKeyValue(RSA key) { }
+
+        public RSA Key { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class Signature
+    {
+        public string? Id { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public Collections.IList ObjectList { get { throw null; } set { } }
+
+        public byte[]? SignatureValue { get { throw null; } set { } }
+
+        public SignedInfo? SignedInfo { get { throw null; } set { } }
+
+        public void AddObject(DataObject dataObject) { }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class SignedInfo : Collections.ICollection, Collections.IEnumerable
+    {
+        public string CanonicalizationMethod { get { throw null; } set { } }
+
+        public Transform CanonicalizationMethodObject { get { throw null; } }
+
+        public int Count { get { throw null; } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public Collections.ArrayList References { get { throw null; } }
+
+        public string? SignatureLength { get { throw null; } set { } }
+
+        public string? SignatureMethod { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public void AddReference(Reference reference) { }
+
+        public void CopyTo(Array array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class SignedXml
+    {
+        protected Signature m_signature;
+        protected string? m_strSigningKeyName;
+        public const string XmlDecryptionTransformUrl = "http://www.w3.org/2002/07/decrypt#XML";
+        public const string XmlDsigBase64TransformUrl = "http://www.w3.org/2000/09/xmldsig#base64";
+        public const string XmlDsigC14NTransformUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+        public const string XmlDsigC14NWithCommentsTransformUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
+        public const string XmlDsigCanonicalizationUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+        public const string XmlDsigCanonicalizationWithCommentsUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
+        public const string XmlDsigDSAUrl = "http://www.w3.org/2000/09/xmldsig#dsa-sha1";
+        public const string XmlDsigEnvelopedSignatureTransformUrl = "http://www.w3.org/2000/09/xmldsig#enveloped-signature";
+        public const string XmlDsigExcC14NTransformUrl = "http://www.w3.org/2001/10/xml-exc-c14n#";
+        public const string XmlDsigExcC14NWithCommentsTransformUrl = "http://www.w3.org/2001/10/xml-exc-c14n#WithComments";
+        public const string XmlDsigHMACSHA1Url = "http://www.w3.org/2000/09/xmldsig#hmac-sha1";
+        public const string XmlDsigMinimalCanonicalizationUrl = "http://www.w3.org/2000/09/xmldsig#minimal";
+        public const string XmlDsigNamespaceUrl = "http://www.w3.org/2000/09/xmldsig#";
+        public const string XmlDsigRSASHA1Url = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+        public const string XmlDsigRSASHA256Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+        public const string XmlDsigRSASHA384Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384";
+        public const string XmlDsigRSASHA512Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512";
+        public const string XmlDsigSHA1Url = "http://www.w3.org/2000/09/xmldsig#sha1";
+        public const string XmlDsigSHA256Url = "http://www.w3.org/2001/04/xmlenc#sha256";
+        public const string XmlDsigSHA384Url = "http://www.w3.org/2001/04/xmldsig-more#sha384";
+        public const string XmlDsigSHA512Url = "http://www.w3.org/2001/04/xmlenc#sha512";
+        public const string XmlDsigXPathTransformUrl = "http://www.w3.org/TR/1999/REC-xpath-19991116";
+        public const string XmlDsigXsltTransformUrl = "http://www.w3.org/TR/1999/REC-xslt-19991116";
+        public const string XmlLicenseTransformUrl = "urn:mpeg:mpeg21:2003:01-REL-R-NS:licenseTransform";
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public SignedXml() { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public SignedXml(System.Xml.XmlDocument document) { }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public SignedXml(System.Xml.XmlElement elem) { }
+
+        public EncryptedXml EncryptedXml { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public System.Xml.XmlResolver Resolver { set { } }
+
+        public Collections.ObjectModel.Collection<string> SafeCanonicalizationMethods { get { throw null; } }
+
+        public Signature Signature { get { throw null; } }
+
+        public Func<SignedXml, bool> SignatureFormatValidator { get { throw null; } set { } }
+
+        public string? SignatureLength { get { throw null; } }
+
+        public string? SignatureMethod { get { throw null; } }
+
+        public byte[]? SignatureValue { get { throw null; } }
+
+        public SignedInfo? SignedInfo { get { throw null; } }
+
+        public AsymmetricAlgorithm? SigningKey { get { throw null; } set { } }
+
+        public string? SigningKeyName { get { throw null; } set { } }
+
+        public void AddObject(DataObject dataObject) { }
+
+        public void AddReference(Reference reference) { }
+
+        public bool CheckSignature() { throw null; }
+
+        public bool CheckSignature(AsymmetricAlgorithm key) { throw null; }
+
+        public bool CheckSignature(KeyedHashAlgorithm macAlg) { throw null; }
+
+        public bool CheckSignature(X509Certificates.X509Certificate2 certificate, bool verifySignatureOnly) { throw null; }
+
+        public bool CheckSignatureReturningKey(out AsymmetricAlgorithm? signingKey) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RDC")]
+        public void ComputeSignature() { }
+
+        public void ComputeSignature(KeyedHashAlgorithm macAlg) { }
+
+        public virtual System.Xml.XmlElement? GetIdElement(System.Xml.XmlDocument? document, string idValue) { throw null; }
+
+        protected virtual AsymmetricAlgorithm? GetPublicKey() { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class Transform
+    {
+        public string? Algorithm { get { throw null; } set { } }
+
+        public System.Xml.XmlElement? Context { get { throw null; } set { } }
+
+        public abstract Type[] InputTypes { get; }
+        public abstract Type[] OutputTypes { get; }
+
+        public Collections.Hashtable PropagatedNamespaces { get { throw null; } }
+
+        public System.Xml.XmlResolver? Resolver { set { } }
+
+        public virtual byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected abstract System.Xml.XmlNodeList? GetInnerXml();
+        public abstract object GetOutput();
+        public abstract object GetOutput(Type type);
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public abstract void LoadInnerXml(System.Xml.XmlNodeList nodeList);
+        public abstract void LoadInput(object obj);
+    }
+
+    public partial class TransformChain
+    {
+        public int Count { get { throw null; } }
+
+        public Transform this[int index] { get { throw null; } }
+
+        public void Add(Transform transform) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class XmlDecryptionTransform : Transform
+    {
+        public EncryptedXml EncryptedXml { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public void AddExceptUri(string uri) { }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        protected virtual bool IsTargetElement(System.Xml.XmlElement? inputElement, string idValue) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigBase64Transform : Transform
+    {
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigC14NTransform : Transform
+    {
+        public XmlDsigC14NTransform() { }
+
+        public XmlDsigC14NTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public override byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigC14NWithCommentsTransform : XmlDsigC14NTransform
+    {
+    }
+
+    public partial class XmlDsigEnvelopedSignatureTransform : Transform
+    {
+        public XmlDsigEnvelopedSignatureTransform() { }
+
+        public XmlDsigEnvelopedSignatureTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigExcC14NTransform : Transform
+    {
+        public XmlDsigExcC14NTransform() { }
+
+        public XmlDsigExcC14NTransform(bool includeComments, string? inclusiveNamespacesPrefixList) { }
+
+        public XmlDsigExcC14NTransform(bool includeComments) { }
+
+        public XmlDsigExcC14NTransform(string inclusiveNamespacesPrefixList) { }
+
+        public string? InclusiveNamespacesPrefixList { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public override byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigExcC14NWithCommentsTransform : XmlDsigExcC14NTransform
+    {
+        public XmlDsigExcC14NWithCommentsTransform() { }
+
+        public XmlDsigExcC14NWithCommentsTransform(string inclusiveNamespacesPrefixList) { }
+    }
+
+    public partial class XmlDsigXPathTransform : Transform
+    {
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigXsltTransform : Transform
+    {
+        public XmlDsigXsltTransform() { }
+
+        public XmlDsigXsltTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class XmlLicenseTransform : Transform
+    {
+        public IRelDecryptor? Decryptor { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.xml/8.0.4/lib/net7.0/System.Security.Cryptography.Xml.cs
+++ b/src/referencePackages/src/system.security.cryptography.xml/8.0.4/lib/net7.0/System.Security.Cryptography.Xml.cs
@@ -1,0 +1,955 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v7.0", FrameworkDisplayName = ".NET 7.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Security.Cryptography.Xml")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides classes to support the creation and validation of XML digital signatures. The classes in this namespace implement the World Wide Web Consortium Recommendation, \"XML-Signature Syntax and Processing\", described at http://www.w3.org/TR/xmldsig-core/.\r\n\r\nCommonly Used Types:\r\nSystem.Security.Cryptography.Xml.CipherData\r\nSystem.Security.Cryptography.Xml.CipherReference\r\nSystem.Security.Cryptography.Xml.DataObject\r\nSystem.Security.Cryptography.Xml.DataReference\r\nSystem.Security.Cryptography.Xml.DSAKeyValue\r\nSystem.Security.Cryptography.Xml.EncryptedData\r\nSystem.Security.Cryptography.Xml.EncryptedKey\r\nSystem.Security.Cryptography.Xml.EncryptedReference\r\nSystem.Security.Cryptography.Xml.EncryptedType\r\nSystem.Security.Cryptography.Xml.EncryptedXml\r\nSystem.Security.Cryptography.Xml.EncryptionMethod\r\nSystem.Security.Cryptography.Xml.EncryptionProperty\r\nSystem.Security.Cryptography.Xml.EncryptionPropertyCollection\r\nSystem.Security.Cryptography.Xml.KeyInfo\r\nSystem.Security.Cryptography.Xml.KeyInfoClause\r\nSystem.Security.Cryptography.Xml.KeyInfoEncryptedKey\r\nSystem.Security.Cryptography.Xml.KeyInfoName\r\nSystem.Security.Cryptography.Xml.KeyInfoNode\r\nSystem.Security.Cryptography.Xml.KeyInfoRetrievalMethod\r\nSystem.Security.Cryptography.Xml.KeyInfoX509Data\r\nSystem.Security.Cryptography.Xml.KeyReference\r\nSystem.Security.Cryptography.Xml.Reference\r\nSystem.Security.Cryptography.Xml.ReferenceList\r\nSystem.Security.Cryptography.Xml.RSAKeyValue\r\nSystem.Security.Cryptography.Xml.Signature\r\nSystem.Security.Cryptography.Xml.SignedInfo\r\nSystem.Security.Cryptography.Xml.SignedXml\r\nSystem.Security.Cryptography.Xml.Transform\r\nSystem.Security.Cryptography.Xml.TransformChain\r\nSystem.Security.Cryptography.Xml.XmlDecryptionTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigBase64Transform\r\nSystem.Security.Cryptography.Xml.XmlDsigC14NTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigC14NWithCommentsTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigEnvelopedSignatureTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigExcC14NTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigExcC14NWithCommentsTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigXPathTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigXsltTransform\r\nSystem.Security.Cryptography.Xml.XmlLicenseTransform")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.2926.32403")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.29+18fd75c847399745c43b5970fec840ba71064e80")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Security.Cryptography.Xml")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Security.Cryptography.Xml
+{
+    public sealed partial class CipherData
+    {
+        public CipherData() { }
+
+        public CipherData(byte[] cipherValue) { }
+
+        public CipherData(CipherReference cipherReference) { }
+
+        public CipherReference? CipherReference { get { throw null; } set { } }
+
+        public byte[]? CipherValue { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class CipherReference : EncryptedReference
+    {
+        public CipherReference() { }
+
+        public CipherReference(string uri, TransformChain transformChain) { }
+
+        public CipherReference(string uri) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class CryptoSignedXmlRecursionException : System.Xml.XmlException
+    {
+        public CryptoSignedXmlRecursionException() { }
+
+        protected CryptoSignedXmlRecursionException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+
+        public CryptoSignedXmlRecursionException(string message, Exception inner) { }
+
+        public CryptoSignedXmlRecursionException(string message) { }
+    }
+
+    public partial class DataObject
+    {
+        public DataObject() { }
+
+        public DataObject(string id, string mimeType, string encoding, System.Xml.XmlElement data) { }
+
+        public System.Xml.XmlNodeList Data { get { throw null; } set { } }
+
+        public string? Encoding { get { throw null; } set { } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public string? MimeType { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class DataReference : EncryptedReference
+    {
+        public DataReference() { }
+
+        public DataReference(string uri, TransformChain transformChain) { }
+
+        public DataReference(string uri) { }
+    }
+
+    public partial class DSAKeyValue : KeyInfoClause
+    {
+        [Runtime.Versioning.UnsupportedOSPlatform("ios")]
+        [Runtime.Versioning.UnsupportedOSPlatform("tvos")]
+        public DSAKeyValue() { }
+
+        public DSAKeyValue(DSA key) { }
+
+        public DSA Key { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptedData : EncryptedType
+    {
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptedKey : EncryptedType
+    {
+        public string? CarriedKeyName { get { throw null; } set { } }
+
+        public string Recipient { get { throw null; } set { } }
+
+        public ReferenceList ReferenceList { get { throw null; } }
+
+        public void AddReference(DataReference dataReference) { }
+
+        public void AddReference(KeyReference keyReference) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class EncryptedReference
+    {
+        protected EncryptedReference() { }
+
+        protected EncryptedReference(string uri, TransformChain transformChain) { }
+
+        protected EncryptedReference(string uri) { }
+
+        [Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "_cachedXml")]
+        protected internal bool CacheValid { get { throw null; } }
+
+        protected string? ReferenceType { get { throw null; } set { } }
+
+        public TransformChain TransformChain { get { throw null; } set { } }
+
+        public string Uri { get { throw null; } set { } }
+
+        public void AddTransform(Transform transform) { }
+
+        public virtual System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public virtual void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class EncryptedType
+    {
+        public virtual CipherData CipherData { get { throw null; } set { } }
+
+        public virtual string? Encoding { get { throw null; } set { } }
+
+        public virtual EncryptionMethod? EncryptionMethod { get { throw null; } set { } }
+
+        public virtual EncryptionPropertyCollection EncryptionProperties { get { throw null; } }
+
+        public virtual string? Id { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public virtual string? MimeType { get { throw null; } set { } }
+
+        public virtual string? Type { get { throw null; } set { } }
+
+        public void AddProperty(EncryptionProperty ep) { }
+
+        public abstract System.Xml.XmlElement GetXml();
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public abstract void LoadXml(System.Xml.XmlElement value);
+    }
+
+    public partial class EncryptedXml
+    {
+        public const string XmlEncAES128KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes128";
+        public const string XmlEncAES128Url = "http://www.w3.org/2001/04/xmlenc#aes128-cbc";
+        public const string XmlEncAES192KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes192";
+        public const string XmlEncAES192Url = "http://www.w3.org/2001/04/xmlenc#aes192-cbc";
+        public const string XmlEncAES256KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes256";
+        public const string XmlEncAES256Url = "http://www.w3.org/2001/04/xmlenc#aes256-cbc";
+        public const string XmlEncDESUrl = "http://www.w3.org/2001/04/xmlenc#des-cbc";
+        public const string XmlEncElementContentUrl = "http://www.w3.org/2001/04/xmlenc#Content";
+        public const string XmlEncElementUrl = "http://www.w3.org/2001/04/xmlenc#Element";
+        public const string XmlEncEncryptedKeyUrl = "http://www.w3.org/2001/04/xmlenc#EncryptedKey";
+        public const string XmlEncNamespaceUrl = "http://www.w3.org/2001/04/xmlenc#";
+        public const string XmlEncRSA15Url = "http://www.w3.org/2001/04/xmlenc#rsa-1_5";
+        public const string XmlEncRSAOAEPUrl = "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p";
+        public const string XmlEncSHA256Url = "http://www.w3.org/2001/04/xmlenc#sha256";
+        public const string XmlEncSHA512Url = "http://www.w3.org/2001/04/xmlenc#sha512";
+        public const string XmlEncTripleDESKeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-tripledes";
+        public const string XmlEncTripleDESUrl = "http://www.w3.org/2001/04/xmlenc#tripledes-cbc";
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public EncryptedXml() { }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public EncryptedXml(System.Xml.XmlDocument document, Policy.Evidence? evidence) { }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public EncryptedXml(System.Xml.XmlDocument document) { }
+
+        public Policy.Evidence? DocumentEvidence { get { throw null; } set { } }
+
+        public Text.Encoding Encoding { get { throw null; } set { } }
+
+        public CipherMode Mode { get { throw null; } set { } }
+
+        public PaddingMode Padding { get { throw null; } set { } }
+
+        public string Recipient { get { throw null; } set { } }
+
+        public System.Xml.XmlResolver? Resolver { get { throw null; } set { } }
+
+        public int XmlDSigSearchDepth { get { throw null; } set { } }
+
+        public void AddKeyNameMapping(string keyName, object keyObject) { }
+
+        public void ClearKeyNameMappings() { }
+
+        public byte[] DecryptData(EncryptedData encryptedData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public void DecryptDocument() { }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public virtual byte[]? DecryptEncryptedKey(EncryptedKey encryptedKey) { throw null; }
+
+        public static byte[] DecryptKey(byte[] keyData, RSA rsa, bool useOAEP) { throw null; }
+
+        public static byte[] DecryptKey(byte[] keyData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public EncryptedData Encrypt(System.Xml.XmlElement inputElement, X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public EncryptedData Encrypt(System.Xml.XmlElement inputElement, string keyName) { throw null; }
+
+        public byte[] EncryptData(byte[] plaintext, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        public byte[] EncryptData(System.Xml.XmlElement inputElement, SymmetricAlgorithm symmetricAlgorithm, bool content) { throw null; }
+
+        public static byte[] EncryptKey(byte[] keyData, RSA rsa, bool useOAEP) { throw null; }
+
+        public static byte[] EncryptKey(byte[] keyData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        public virtual byte[] GetDecryptionIV(EncryptedData encryptedData, string? symmetricAlgorithmUri) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public virtual SymmetricAlgorithm? GetDecryptionKey(EncryptedData encryptedData, string? symmetricAlgorithmUri) { throw null; }
+
+        public virtual System.Xml.XmlElement? GetIdElement(System.Xml.XmlDocument document, string idValue) { throw null; }
+
+        public void ReplaceData(System.Xml.XmlElement inputElement, byte[] decryptedData) { }
+
+        public static void ReplaceElement(System.Xml.XmlElement inputElement, EncryptedData encryptedData, bool content) { }
+    }
+
+    public partial class EncryptionMethod
+    {
+        public EncryptionMethod() { }
+
+        public EncryptionMethod(string? algorithm) { }
+
+        public string? KeyAlgorithm { get { throw null; } set { } }
+
+        public int KeySize { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptionProperty
+    {
+        public EncryptionProperty() { }
+
+        public EncryptionProperty(System.Xml.XmlElement elementProperty) { }
+
+        public string? Id { get { throw null; } }
+
+        public System.Xml.XmlElement? PropertyElement { get { throw null; } set { } }
+
+        public string? Target { get { throw null; } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptionPropertyCollection : Collections.IList, Collections.ICollection, Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public bool IsFixedSize { get { throw null; } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        [System.Runtime.CompilerServices.IndexerName("ItemOf")]
+        public EncryptionProperty this[int index] { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        object? Collections.IList.this[int index] { get { throw null; } set { } }
+
+        public int Add(EncryptionProperty value) { throw null; }
+
+        public void Clear() { }
+
+        public bool Contains(EncryptionProperty value) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(EncryptionProperty[] array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public int IndexOf(EncryptionProperty value) { throw null; }
+
+        public void Insert(int index, EncryptionProperty value) { }
+
+        public EncryptionProperty Item(int index) { throw null; }
+
+        public void Remove(EncryptionProperty value) { }
+
+        public void RemoveAt(int index) { }
+
+        int Collections.IList.Add(object value) { throw null; }
+
+        bool Collections.IList.Contains(object value) { throw null; }
+
+        int Collections.IList.IndexOf(object value) { throw null; }
+
+        void Collections.IList.Insert(int index, object value) { }
+
+        void Collections.IList.Remove(object value) { }
+    }
+
+    public partial interface IRelDecryptor
+    {
+        IO.Stream Decrypt(EncryptionMethod encryptionMethod, KeyInfo keyInfo, IO.Stream toDecrypt);
+    }
+
+    public partial class KeyInfo : Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public void AddClause(KeyInfoClause clause) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public Collections.IEnumerator GetEnumerator(Type requestedObjectType) { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class KeyInfoClause
+    {
+        public abstract System.Xml.XmlElement GetXml();
+        public abstract void LoadXml(System.Xml.XmlElement element);
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class KeyInfoEncryptedKey : KeyInfoClause
+    {
+        public KeyInfoEncryptedKey() { }
+
+        public KeyInfoEncryptedKey(EncryptedKey encryptedKey) { }
+
+        public EncryptedKey? EncryptedKey { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoName : KeyInfoClause
+    {
+        public KeyInfoName() { }
+
+        public KeyInfoName(string? keyName) { }
+
+        public string? Value { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoNode : KeyInfoClause
+    {
+        public KeyInfoNode() { }
+
+        public KeyInfoNode(System.Xml.XmlElement node) { }
+
+        public System.Xml.XmlElement? Value { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoRetrievalMethod : KeyInfoClause
+    {
+        public KeyInfoRetrievalMethod() { }
+
+        public KeyInfoRetrievalMethod(string strUri, string typeName) { }
+
+        public KeyInfoRetrievalMethod(string? strUri) { }
+
+        public string? Type { get { throw null; } set { } }
+
+        public string? Uri { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoX509Data : KeyInfoClause
+    {
+        public KeyInfoX509Data() { }
+
+        public KeyInfoX509Data(byte[] rgbCert) { }
+
+        public KeyInfoX509Data(X509Certificates.X509Certificate cert, X509Certificates.X509IncludeOption includeOption) { }
+
+        public KeyInfoX509Data(X509Certificates.X509Certificate cert) { }
+
+        public Collections.ArrayList? Certificates { get { throw null; } }
+
+        public byte[]? CRL { get { throw null; } set { } }
+
+        public Collections.ArrayList? IssuerSerials { get { throw null; } }
+
+        public Collections.ArrayList? SubjectKeyIds { get { throw null; } }
+
+        public Collections.ArrayList? SubjectNames { get { throw null; } }
+
+        public void AddCertificate(X509Certificates.X509Certificate certificate) { }
+
+        public void AddIssuerSerial(string issuerName, string serialNumber) { }
+
+        public void AddSubjectKeyId(byte[] subjectKeyId) { }
+
+        public void AddSubjectKeyId(string subjectKeyId) { }
+
+        public void AddSubjectName(string subjectName) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement element) { }
+    }
+
+    public sealed partial class KeyReference : EncryptedReference
+    {
+        public KeyReference() { }
+
+        public KeyReference(string uri, TransformChain transformChain) { }
+
+        public KeyReference(string uri) { }
+    }
+
+    public partial class Reference
+    {
+        public Reference() { }
+
+        public Reference(IO.Stream stream) { }
+
+        public Reference(string? uri) { }
+
+        public string DigestMethod { get { throw null; } set { } }
+
+        public byte[]? DigestValue { get { throw null; } set { } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public TransformChain TransformChain { get { throw null; } set { } }
+
+        public string? Type { get { throw null; } set { } }
+
+        public string? Uri { get { throw null; } set { } }
+
+        public void AddTransform(Transform transform) { }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class ReferenceList : Collections.IList, Collections.ICollection, Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        [System.Runtime.CompilerServices.IndexerName("ItemOf")]
+        public EncryptedReference this[int index] { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        bool Collections.IList.IsFixedSize { get { throw null; } }
+
+        bool Collections.IList.IsReadOnly { get { throw null; } }
+
+        object? Collections.IList.this[int index] { get { throw null; } set { } }
+
+        public int Add(object? value) { throw null; }
+
+        public void Clear() { }
+
+        public bool Contains(object? value) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public int IndexOf(object? value) { throw null; }
+
+        public void Insert(int index, object? value) { }
+
+        public EncryptedReference? Item(int index) { throw null; }
+
+        public void Remove(object? value) { }
+
+        public void RemoveAt(int index) { }
+    }
+
+    public partial class RSAKeyValue : KeyInfoClause
+    {
+        public RSAKeyValue() { }
+
+        public RSAKeyValue(RSA key) { }
+
+        public RSA Key { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class Signature
+    {
+        public string? Id { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public Collections.IList ObjectList { get { throw null; } set { } }
+
+        public byte[]? SignatureValue { get { throw null; } set { } }
+
+        public SignedInfo? SignedInfo { get { throw null; } set { } }
+
+        public void AddObject(DataObject dataObject) { }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class SignedInfo : Collections.ICollection, Collections.IEnumerable
+    {
+        public string CanonicalizationMethod { get { throw null; } set { } }
+
+        public Transform CanonicalizationMethodObject { get { throw null; } }
+
+        public int Count { get { throw null; } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public Collections.ArrayList References { get { throw null; } }
+
+        public string? SignatureLength { get { throw null; } set { } }
+
+        public string? SignatureMethod { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public void AddReference(Reference reference) { }
+
+        public void CopyTo(Array array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class SignedXml
+    {
+        protected Signature m_signature;
+        protected string? m_strSigningKeyName;
+        public const string XmlDecryptionTransformUrl = "http://www.w3.org/2002/07/decrypt#XML";
+        public const string XmlDsigBase64TransformUrl = "http://www.w3.org/2000/09/xmldsig#base64";
+        public const string XmlDsigC14NTransformUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+        public const string XmlDsigC14NWithCommentsTransformUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
+        public const string XmlDsigCanonicalizationUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+        public const string XmlDsigCanonicalizationWithCommentsUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
+        public const string XmlDsigDSAUrl = "http://www.w3.org/2000/09/xmldsig#dsa-sha1";
+        public const string XmlDsigEnvelopedSignatureTransformUrl = "http://www.w3.org/2000/09/xmldsig#enveloped-signature";
+        public const string XmlDsigExcC14NTransformUrl = "http://www.w3.org/2001/10/xml-exc-c14n#";
+        public const string XmlDsigExcC14NWithCommentsTransformUrl = "http://www.w3.org/2001/10/xml-exc-c14n#WithComments";
+        public const string XmlDsigHMACSHA1Url = "http://www.w3.org/2000/09/xmldsig#hmac-sha1";
+        public const string XmlDsigMinimalCanonicalizationUrl = "http://www.w3.org/2000/09/xmldsig#minimal";
+        public const string XmlDsigNamespaceUrl = "http://www.w3.org/2000/09/xmldsig#";
+        public const string XmlDsigRSASHA1Url = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+        public const string XmlDsigRSASHA256Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+        public const string XmlDsigRSASHA384Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384";
+        public const string XmlDsigRSASHA512Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512";
+        public const string XmlDsigSHA1Url = "http://www.w3.org/2000/09/xmldsig#sha1";
+        public const string XmlDsigSHA256Url = "http://www.w3.org/2001/04/xmlenc#sha256";
+        public const string XmlDsigSHA384Url = "http://www.w3.org/2001/04/xmldsig-more#sha384";
+        public const string XmlDsigSHA512Url = "http://www.w3.org/2001/04/xmlenc#sha512";
+        public const string XmlDsigXPathTransformUrl = "http://www.w3.org/TR/1999/REC-xpath-19991116";
+        public const string XmlDsigXsltTransformUrl = "http://www.w3.org/TR/1999/REC-xslt-19991116";
+        public const string XmlLicenseTransformUrl = "urn:mpeg:mpeg21:2003:01-REL-R-NS:licenseTransform";
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public SignedXml() { }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public SignedXml(System.Xml.XmlDocument document) { }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public SignedXml(System.Xml.XmlElement elem) { }
+
+        public EncryptedXml EncryptedXml { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public System.Xml.XmlResolver Resolver { set { } }
+
+        public Collections.ObjectModel.Collection<string> SafeCanonicalizationMethods { get { throw null; } }
+
+        public Signature Signature { get { throw null; } }
+
+        public Func<SignedXml, bool> SignatureFormatValidator { get { throw null; } set { } }
+
+        public string? SignatureLength { get { throw null; } }
+
+        public string? SignatureMethod { get { throw null; } }
+
+        public byte[]? SignatureValue { get { throw null; } }
+
+        public SignedInfo? SignedInfo { get { throw null; } }
+
+        public AsymmetricAlgorithm? SigningKey { get { throw null; } set { } }
+
+        public string? SigningKeyName { get { throw null; } set { } }
+
+        public void AddObject(DataObject dataObject) { }
+
+        public void AddReference(Reference reference) { }
+
+        public bool CheckSignature() { throw null; }
+
+        public bool CheckSignature(AsymmetricAlgorithm key) { throw null; }
+
+        public bool CheckSignature(KeyedHashAlgorithm macAlg) { throw null; }
+
+        public bool CheckSignature(X509Certificates.X509Certificate2 certificate, bool verifySignatureOnly) { throw null; }
+
+        public bool CheckSignatureReturningKey(out AsymmetricAlgorithm? signingKey) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RDC")]
+        public void ComputeSignature() { }
+
+        public void ComputeSignature(KeyedHashAlgorithm macAlg) { }
+
+        public virtual System.Xml.XmlElement? GetIdElement(System.Xml.XmlDocument? document, string idValue) { throw null; }
+
+        protected virtual AsymmetricAlgorithm? GetPublicKey() { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class Transform
+    {
+        public string? Algorithm { get { throw null; } set { } }
+
+        public System.Xml.XmlElement? Context { get { throw null; } set { } }
+
+        public abstract Type[] InputTypes { get; }
+        public abstract Type[] OutputTypes { get; }
+
+        public Collections.Hashtable PropagatedNamespaces { get { throw null; } }
+
+        public System.Xml.XmlResolver? Resolver { set { } }
+
+        public virtual byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected abstract System.Xml.XmlNodeList? GetInnerXml();
+        public abstract object GetOutput();
+        public abstract object GetOutput(Type type);
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public abstract void LoadInnerXml(System.Xml.XmlNodeList nodeList);
+        public abstract void LoadInput(object obj);
+    }
+
+    public partial class TransformChain
+    {
+        public int Count { get { throw null; } }
+
+        public Transform this[int index] { get { throw null; } }
+
+        public void Add(Transform transform) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class XmlDecryptionTransform : Transform
+    {
+        public EncryptedXml EncryptedXml { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public void AddExceptUri(string uri) { }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        protected virtual bool IsTargetElement(System.Xml.XmlElement? inputElement, string idValue) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigBase64Transform : Transform
+    {
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigC14NTransform : Transform
+    {
+        public XmlDsigC14NTransform() { }
+
+        public XmlDsigC14NTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public override byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigC14NWithCommentsTransform : XmlDsigC14NTransform
+    {
+    }
+
+    public partial class XmlDsigEnvelopedSignatureTransform : Transform
+    {
+        public XmlDsigEnvelopedSignatureTransform() { }
+
+        public XmlDsigEnvelopedSignatureTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigExcC14NTransform : Transform
+    {
+        public XmlDsigExcC14NTransform() { }
+
+        public XmlDsigExcC14NTransform(bool includeComments, string? inclusiveNamespacesPrefixList) { }
+
+        public XmlDsigExcC14NTransform(bool includeComments) { }
+
+        public XmlDsigExcC14NTransform(string inclusiveNamespacesPrefixList) { }
+
+        public string? InclusiveNamespacesPrefixList { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public override byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigExcC14NWithCommentsTransform : XmlDsigExcC14NTransform
+    {
+        public XmlDsigExcC14NWithCommentsTransform() { }
+
+        public XmlDsigExcC14NWithCommentsTransform(string inclusiveNamespacesPrefixList) { }
+    }
+
+    public partial class XmlDsigXPathTransform : Transform
+    {
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+    public partial class XmlDsigXsltTransform : Transform
+    {
+        public XmlDsigXsltTransform() { }
+
+        public XmlDsigXsltTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class XmlLicenseTransform : Transform
+    {
+        public IRelDecryptor? Decryptor { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.xml/8.0.4/lib/net8.0/System.Security.Cryptography.Xml.cs
+++ b/src/referencePackages/src/system.security.cryptography.xml/8.0.4/lib/net8.0/System.Security.Cryptography.Xml.cs
@@ -1,0 +1,956 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName = ".NET 8.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Security.Cryptography.Xml")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.Versioning.UnsupportedOSPlatform("browser")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides classes to support the creation and validation of XML digital signatures. The classes in this namespace implement the World Wide Web Consortium Recommendation, \"XML-Signature Syntax and Processing\", described at http://www.w3.org/TR/xmldsig-core/.\r\n\r\nCommonly Used Types:\r\nSystem.Security.Cryptography.Xml.CipherData\r\nSystem.Security.Cryptography.Xml.CipherReference\r\nSystem.Security.Cryptography.Xml.DataObject\r\nSystem.Security.Cryptography.Xml.DataReference\r\nSystem.Security.Cryptography.Xml.DSAKeyValue\r\nSystem.Security.Cryptography.Xml.EncryptedData\r\nSystem.Security.Cryptography.Xml.EncryptedKey\r\nSystem.Security.Cryptography.Xml.EncryptedReference\r\nSystem.Security.Cryptography.Xml.EncryptedType\r\nSystem.Security.Cryptography.Xml.EncryptedXml\r\nSystem.Security.Cryptography.Xml.EncryptionMethod\r\nSystem.Security.Cryptography.Xml.EncryptionProperty\r\nSystem.Security.Cryptography.Xml.EncryptionPropertyCollection\r\nSystem.Security.Cryptography.Xml.KeyInfo\r\nSystem.Security.Cryptography.Xml.KeyInfoClause\r\nSystem.Security.Cryptography.Xml.KeyInfoEncryptedKey\r\nSystem.Security.Cryptography.Xml.KeyInfoName\r\nSystem.Security.Cryptography.Xml.KeyInfoNode\r\nSystem.Security.Cryptography.Xml.KeyInfoRetrievalMethod\r\nSystem.Security.Cryptography.Xml.KeyInfoX509Data\r\nSystem.Security.Cryptography.Xml.KeyReference\r\nSystem.Security.Cryptography.Xml.Reference\r\nSystem.Security.Cryptography.Xml.ReferenceList\r\nSystem.Security.Cryptography.Xml.RSAKeyValue\r\nSystem.Security.Cryptography.Xml.Signature\r\nSystem.Security.Cryptography.Xml.SignedInfo\r\nSystem.Security.Cryptography.Xml.SignedXml\r\nSystem.Security.Cryptography.Xml.Transform\r\nSystem.Security.Cryptography.Xml.TransformChain\r\nSystem.Security.Cryptography.Xml.XmlDecryptionTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigBase64Transform\r\nSystem.Security.Cryptography.Xml.XmlDsigC14NTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigC14NWithCommentsTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigEnvelopedSignatureTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigExcC14NTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigExcC14NWithCommentsTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigXPathTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigXsltTransform\r\nSystem.Security.Cryptography.Xml.XmlLicenseTransform")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.2926.32403")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.29+18fd75c847399745c43b5970fec840ba71064e80")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Security.Cryptography.Xml")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Security.Cryptography.Xml
+{
+    public sealed partial class CipherData
+    {
+        public CipherData() { }
+
+        public CipherData(byte[] cipherValue) { }
+
+        public CipherData(CipherReference cipherReference) { }
+
+        public CipherReference? CipherReference { get { throw null; } set { } }
+
+        public byte[]? CipherValue { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class CipherReference : EncryptedReference
+    {
+        public CipherReference() { }
+
+        public CipherReference(string uri, TransformChain transformChain) { }
+
+        public CipherReference(string uri) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class CryptoSignedXmlRecursionException : System.Xml.XmlException
+    {
+        public CryptoSignedXmlRecursionException() { }
+
+        [Obsolete("This API supports obsolete formatter-based serialization. It should not be called or extended by application code.", DiagnosticId = "SYSLIB0051", UrlFormat = "https://aka.ms/dotnet-warnings/{0}")]
+        protected CryptoSignedXmlRecursionException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+
+        public CryptoSignedXmlRecursionException(string message, Exception inner) { }
+
+        public CryptoSignedXmlRecursionException(string message) { }
+    }
+
+    public partial class DataObject
+    {
+        public DataObject() { }
+
+        public DataObject(string id, string mimeType, string encoding, System.Xml.XmlElement data) { }
+
+        public System.Xml.XmlNodeList Data { get { throw null; } set { } }
+
+        public string? Encoding { get { throw null; } set { } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public string? MimeType { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class DataReference : EncryptedReference
+    {
+        public DataReference() { }
+
+        public DataReference(string uri, TransformChain transformChain) { }
+
+        public DataReference(string uri) { }
+    }
+
+    public partial class DSAKeyValue : KeyInfoClause
+    {
+        [Runtime.Versioning.UnsupportedOSPlatform("ios")]
+        [Runtime.Versioning.UnsupportedOSPlatform("tvos")]
+        public DSAKeyValue() { }
+
+        public DSAKeyValue(DSA key) { }
+
+        public DSA Key { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptedData : EncryptedType
+    {
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptedKey : EncryptedType
+    {
+        public string? CarriedKeyName { get { throw null; } set { } }
+
+        public string Recipient { get { throw null; } set { } }
+
+        public ReferenceList ReferenceList { get { throw null; } }
+
+        public void AddReference(DataReference dataReference) { }
+
+        public void AddReference(KeyReference keyReference) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class EncryptedReference
+    {
+        protected EncryptedReference() { }
+
+        protected EncryptedReference(string uri, TransformChain transformChain) { }
+
+        protected EncryptedReference(string uri) { }
+
+        [Diagnostics.CodeAnalysis.MemberNotNullWhen(true, "_cachedXml")]
+        protected internal bool CacheValid { get { throw null; } }
+
+        protected string? ReferenceType { get { throw null; } set { } }
+
+        public TransformChain TransformChain { get { throw null; } set { } }
+
+        public string Uri { get { throw null; } set { } }
+
+        public void AddTransform(Transform transform) { }
+
+        public virtual System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public virtual void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class EncryptedType
+    {
+        public virtual CipherData CipherData { get { throw null; } set { } }
+
+        public virtual string? Encoding { get { throw null; } set { } }
+
+        public virtual EncryptionMethod? EncryptionMethod { get { throw null; } set { } }
+
+        public virtual EncryptionPropertyCollection EncryptionProperties { get { throw null; } }
+
+        public virtual string? Id { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public virtual string? MimeType { get { throw null; } set { } }
+
+        public virtual string? Type { get { throw null; } set { } }
+
+        public void AddProperty(EncryptionProperty ep) { }
+
+        public abstract System.Xml.XmlElement GetXml();
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public abstract void LoadXml(System.Xml.XmlElement value);
+    }
+
+    public partial class EncryptedXml
+    {
+        public const string XmlEncAES128KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes128";
+        public const string XmlEncAES128Url = "http://www.w3.org/2001/04/xmlenc#aes128-cbc";
+        public const string XmlEncAES192KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes192";
+        public const string XmlEncAES192Url = "http://www.w3.org/2001/04/xmlenc#aes192-cbc";
+        public const string XmlEncAES256KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes256";
+        public const string XmlEncAES256Url = "http://www.w3.org/2001/04/xmlenc#aes256-cbc";
+        public const string XmlEncDESUrl = "http://www.w3.org/2001/04/xmlenc#des-cbc";
+        public const string XmlEncElementContentUrl = "http://www.w3.org/2001/04/xmlenc#Content";
+        public const string XmlEncElementUrl = "http://www.w3.org/2001/04/xmlenc#Element";
+        public const string XmlEncEncryptedKeyUrl = "http://www.w3.org/2001/04/xmlenc#EncryptedKey";
+        public const string XmlEncNamespaceUrl = "http://www.w3.org/2001/04/xmlenc#";
+        public const string XmlEncRSA15Url = "http://www.w3.org/2001/04/xmlenc#rsa-1_5";
+        public const string XmlEncRSAOAEPUrl = "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p";
+        public const string XmlEncSHA256Url = "http://www.w3.org/2001/04/xmlenc#sha256";
+        public const string XmlEncSHA512Url = "http://www.w3.org/2001/04/xmlenc#sha512";
+        public const string XmlEncTripleDESKeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-tripledes";
+        public const string XmlEncTripleDESUrl = "http://www.w3.org/2001/04/xmlenc#tripledes-cbc";
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public EncryptedXml() { }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public EncryptedXml(System.Xml.XmlDocument document, Policy.Evidence? evidence) { }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public EncryptedXml(System.Xml.XmlDocument document) { }
+
+        public Policy.Evidence? DocumentEvidence { get { throw null; } set { } }
+
+        public Text.Encoding Encoding { get { throw null; } set { } }
+
+        public CipherMode Mode { get { throw null; } set { } }
+
+        public PaddingMode Padding { get { throw null; } set { } }
+
+        public string Recipient { get { throw null; } set { } }
+
+        public System.Xml.XmlResolver? Resolver { get { throw null; } set { } }
+
+        public int XmlDSigSearchDepth { get { throw null; } set { } }
+
+        public void AddKeyNameMapping(string keyName, object keyObject) { }
+
+        public void ClearKeyNameMappings() { }
+
+        public byte[] DecryptData(EncryptedData encryptedData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public void DecryptDocument() { }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public virtual byte[]? DecryptEncryptedKey(EncryptedKey encryptedKey) { throw null; }
+
+        public static byte[] DecryptKey(byte[] keyData, RSA rsa, bool useOAEP) { throw null; }
+
+        public static byte[] DecryptKey(byte[] keyData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public EncryptedData Encrypt(System.Xml.XmlElement inputElement, X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public EncryptedData Encrypt(System.Xml.XmlElement inputElement, string keyName) { throw null; }
+
+        public byte[] EncryptData(byte[] plaintext, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        public byte[] EncryptData(System.Xml.XmlElement inputElement, SymmetricAlgorithm symmetricAlgorithm, bool content) { throw null; }
+
+        public static byte[] EncryptKey(byte[] keyData, RSA rsa, bool useOAEP) { throw null; }
+
+        public static byte[] EncryptKey(byte[] keyData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        public virtual byte[] GetDecryptionIV(EncryptedData encryptedData, string? symmetricAlgorithmUri) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public virtual SymmetricAlgorithm? GetDecryptionKey(EncryptedData encryptedData, string? symmetricAlgorithmUri) { throw null; }
+
+        public virtual System.Xml.XmlElement? GetIdElement(System.Xml.XmlDocument document, string idValue) { throw null; }
+
+        public void ReplaceData(System.Xml.XmlElement inputElement, byte[] decryptedData) { }
+
+        public static void ReplaceElement(System.Xml.XmlElement inputElement, EncryptedData encryptedData, bool content) { }
+    }
+
+    public partial class EncryptionMethod
+    {
+        public EncryptionMethod() { }
+
+        public EncryptionMethod(string? algorithm) { }
+
+        public string? KeyAlgorithm { get { throw null; } set { } }
+
+        public int KeySize { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptionProperty
+    {
+        public EncryptionProperty() { }
+
+        public EncryptionProperty(System.Xml.XmlElement elementProperty) { }
+
+        public string? Id { get { throw null; } }
+
+        public System.Xml.XmlElement? PropertyElement { get { throw null; } set { } }
+
+        public string? Target { get { throw null; } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptionPropertyCollection : Collections.IList, Collections.ICollection, Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public bool IsFixedSize { get { throw null; } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        [System.Runtime.CompilerServices.IndexerName("ItemOf")]
+        public EncryptionProperty this[int index] { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        object? Collections.IList.this[int index] { get { throw null; } set { } }
+
+        public int Add(EncryptionProperty value) { throw null; }
+
+        public void Clear() { }
+
+        public bool Contains(EncryptionProperty value) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(EncryptionProperty[] array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public int IndexOf(EncryptionProperty value) { throw null; }
+
+        public void Insert(int index, EncryptionProperty value) { }
+
+        public EncryptionProperty Item(int index) { throw null; }
+
+        public void Remove(EncryptionProperty value) { }
+
+        public void RemoveAt(int index) { }
+
+        int Collections.IList.Add(object value) { throw null; }
+
+        bool Collections.IList.Contains(object value) { throw null; }
+
+        int Collections.IList.IndexOf(object value) { throw null; }
+
+        void Collections.IList.Insert(int index, object value) { }
+
+        void Collections.IList.Remove(object value) { }
+    }
+
+    public partial interface IRelDecryptor
+    {
+        IO.Stream Decrypt(EncryptionMethod encryptionMethod, KeyInfo keyInfo, IO.Stream toDecrypt);
+    }
+
+    public partial class KeyInfo : Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public void AddClause(KeyInfoClause clause) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public Collections.IEnumerator GetEnumerator(Type requestedObjectType) { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class KeyInfoClause
+    {
+        public abstract System.Xml.XmlElement GetXml();
+        public abstract void LoadXml(System.Xml.XmlElement element);
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class KeyInfoEncryptedKey : KeyInfoClause
+    {
+        public KeyInfoEncryptedKey() { }
+
+        public KeyInfoEncryptedKey(EncryptedKey encryptedKey) { }
+
+        public EncryptedKey? EncryptedKey { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoName : KeyInfoClause
+    {
+        public KeyInfoName() { }
+
+        public KeyInfoName(string? keyName) { }
+
+        public string? Value { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoNode : KeyInfoClause
+    {
+        public KeyInfoNode() { }
+
+        public KeyInfoNode(System.Xml.XmlElement node) { }
+
+        public System.Xml.XmlElement? Value { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoRetrievalMethod : KeyInfoClause
+    {
+        public KeyInfoRetrievalMethod() { }
+
+        public KeyInfoRetrievalMethod(string strUri, string typeName) { }
+
+        public KeyInfoRetrievalMethod(string? strUri) { }
+
+        public string? Type { get { throw null; } set { } }
+
+        public string? Uri { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoX509Data : KeyInfoClause
+    {
+        public KeyInfoX509Data() { }
+
+        public KeyInfoX509Data(byte[] rgbCert) { }
+
+        public KeyInfoX509Data(X509Certificates.X509Certificate cert, X509Certificates.X509IncludeOption includeOption) { }
+
+        public KeyInfoX509Data(X509Certificates.X509Certificate cert) { }
+
+        public Collections.ArrayList? Certificates { get { throw null; } }
+
+        public byte[]? CRL { get { throw null; } set { } }
+
+        public Collections.ArrayList? IssuerSerials { get { throw null; } }
+
+        public Collections.ArrayList? SubjectKeyIds { get { throw null; } }
+
+        public Collections.ArrayList? SubjectNames { get { throw null; } }
+
+        public void AddCertificate(X509Certificates.X509Certificate certificate) { }
+
+        public void AddIssuerSerial(string issuerName, string serialNumber) { }
+
+        public void AddSubjectKeyId(byte[] subjectKeyId) { }
+
+        public void AddSubjectKeyId(string subjectKeyId) { }
+
+        public void AddSubjectName(string subjectName) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement element) { }
+    }
+
+    public sealed partial class KeyReference : EncryptedReference
+    {
+        public KeyReference() { }
+
+        public KeyReference(string uri, TransformChain transformChain) { }
+
+        public KeyReference(string uri) { }
+    }
+
+    public partial class Reference
+    {
+        public Reference() { }
+
+        public Reference(IO.Stream stream) { }
+
+        public Reference(string? uri) { }
+
+        public string DigestMethod { get { throw null; } set { } }
+
+        public byte[]? DigestValue { get { throw null; } set { } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public TransformChain TransformChain { get { throw null; } set { } }
+
+        public string? Type { get { throw null; } set { } }
+
+        public string? Uri { get { throw null; } set { } }
+
+        public void AddTransform(Transform transform) { }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class ReferenceList : Collections.IList, Collections.ICollection, Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        [System.Runtime.CompilerServices.IndexerName("ItemOf")]
+        public EncryptedReference this[int index] { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        bool Collections.IList.IsFixedSize { get { throw null; } }
+
+        bool Collections.IList.IsReadOnly { get { throw null; } }
+
+        object? Collections.IList.this[int index] { get { throw null; } set { } }
+
+        public int Add(object? value) { throw null; }
+
+        public void Clear() { }
+
+        public bool Contains(object? value) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public int IndexOf(object? value) { throw null; }
+
+        public void Insert(int index, object? value) { }
+
+        public EncryptedReference? Item(int index) { throw null; }
+
+        public void Remove(object? value) { }
+
+        public void RemoveAt(int index) { }
+    }
+
+    public partial class RSAKeyValue : KeyInfoClause
+    {
+        public RSAKeyValue() { }
+
+        public RSAKeyValue(RSA key) { }
+
+        public RSA Key { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class Signature
+    {
+        public string? Id { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public Collections.IList ObjectList { get { throw null; } set { } }
+
+        public byte[]? SignatureValue { get { throw null; } set { } }
+
+        public SignedInfo? SignedInfo { get { throw null; } set { } }
+
+        public void AddObject(DataObject dataObject) { }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class SignedInfo : Collections.ICollection, Collections.IEnumerable
+    {
+        public string CanonicalizationMethod { get { throw null; } set { } }
+
+        public Transform CanonicalizationMethodObject { get { throw null; } }
+
+        public int Count { get { throw null; } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public Collections.ArrayList References { get { throw null; } }
+
+        public string? SignatureLength { get { throw null; } set { } }
+
+        public string? SignatureMethod { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public void AddReference(Reference reference) { }
+
+        public void CopyTo(Array array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class SignedXml
+    {
+        protected Signature m_signature;
+        protected string? m_strSigningKeyName;
+        public const string XmlDecryptionTransformUrl = "http://www.w3.org/2002/07/decrypt#XML";
+        public const string XmlDsigBase64TransformUrl = "http://www.w3.org/2000/09/xmldsig#base64";
+        public const string XmlDsigC14NTransformUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+        public const string XmlDsigC14NWithCommentsTransformUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
+        public const string XmlDsigCanonicalizationUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+        public const string XmlDsigCanonicalizationWithCommentsUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
+        public const string XmlDsigDSAUrl = "http://www.w3.org/2000/09/xmldsig#dsa-sha1";
+        public const string XmlDsigEnvelopedSignatureTransformUrl = "http://www.w3.org/2000/09/xmldsig#enveloped-signature";
+        public const string XmlDsigExcC14NTransformUrl = "http://www.w3.org/2001/10/xml-exc-c14n#";
+        public const string XmlDsigExcC14NWithCommentsTransformUrl = "http://www.w3.org/2001/10/xml-exc-c14n#WithComments";
+        public const string XmlDsigHMACSHA1Url = "http://www.w3.org/2000/09/xmldsig#hmac-sha1";
+        public const string XmlDsigMinimalCanonicalizationUrl = "http://www.w3.org/2000/09/xmldsig#minimal";
+        public const string XmlDsigNamespaceUrl = "http://www.w3.org/2000/09/xmldsig#";
+        public const string XmlDsigRSASHA1Url = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+        public const string XmlDsigRSASHA256Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+        public const string XmlDsigRSASHA384Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384";
+        public const string XmlDsigRSASHA512Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512";
+        public const string XmlDsigSHA1Url = "http://www.w3.org/2000/09/xmldsig#sha1";
+        public const string XmlDsigSHA256Url = "http://www.w3.org/2001/04/xmlenc#sha256";
+        public const string XmlDsigSHA384Url = "http://www.w3.org/2001/04/xmldsig-more#sha384";
+        public const string XmlDsigSHA512Url = "http://www.w3.org/2001/04/xmlenc#sha512";
+        public const string XmlDsigXPathTransformUrl = "http://www.w3.org/TR/1999/REC-xpath-19991116";
+        public const string XmlDsigXsltTransformUrl = "http://www.w3.org/TR/1999/REC-xslt-19991116";
+        public const string XmlLicenseTransformUrl = "urn:mpeg:mpeg21:2003:01-REL-R-NS:licenseTransform";
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public SignedXml() { }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public SignedXml(System.Xml.XmlDocument document) { }
+
+        [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+        [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+        public SignedXml(System.Xml.XmlElement elem) { }
+
+        public EncryptedXml EncryptedXml { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public System.Xml.XmlResolver Resolver { set { } }
+
+        public Collections.ObjectModel.Collection<string> SafeCanonicalizationMethods { get { throw null; } }
+
+        public Signature Signature { get { throw null; } }
+
+        public Func<SignedXml, bool> SignatureFormatValidator { get { throw null; } set { } }
+
+        public string? SignatureLength { get { throw null; } }
+
+        public string? SignatureMethod { get { throw null; } }
+
+        public byte[]? SignatureValue { get { throw null; } }
+
+        public SignedInfo? SignedInfo { get { throw null; } }
+
+        public AsymmetricAlgorithm? SigningKey { get { throw null; } set { } }
+
+        public string? SigningKeyName { get { throw null; } set { } }
+
+        public void AddObject(DataObject dataObject) { }
+
+        public void AddReference(Reference reference) { }
+
+        public bool CheckSignature() { throw null; }
+
+        public bool CheckSignature(AsymmetricAlgorithm key) { throw null; }
+
+        public bool CheckSignature(KeyedHashAlgorithm macAlg) { throw null; }
+
+        public bool CheckSignature(X509Certificates.X509Certificate2 certificate, bool verifySignatureOnly) { throw null; }
+
+        public bool CheckSignatureReturningKey(out AsymmetricAlgorithm? signingKey) { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RDC")]
+        public void ComputeSignature() { }
+
+        public void ComputeSignature(KeyedHashAlgorithm macAlg) { }
+
+        public virtual System.Xml.XmlElement? GetIdElement(System.Xml.XmlDocument? document, string idValue) { throw null; }
+
+        protected virtual AsymmetricAlgorithm? GetPublicKey() { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("AOT", "IL3050:RequiresDynamicCode", Justification = "ctors are marked as RDC")]
+        [Diagnostics.CodeAnalysis.UnconditionalSuppressMessage("ILLink", "IL2026:RequiresUnreferencedCode", Justification = "ctors are marked as RUC")]
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class Transform
+    {
+        public string? Algorithm { get { throw null; } set { } }
+
+        public System.Xml.XmlElement? Context { get { throw null; } set { } }
+
+        public abstract Type[] InputTypes { get; }
+        public abstract Type[] OutputTypes { get; }
+
+        public Collections.Hashtable PropagatedNamespaces { get { throw null; } }
+
+        public System.Xml.XmlResolver? Resolver { set { } }
+
+        public virtual byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected abstract System.Xml.XmlNodeList? GetInnerXml();
+        public abstract object GetOutput();
+        public abstract object GetOutput(Type type);
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public abstract void LoadInnerXml(System.Xml.XmlNodeList nodeList);
+        public abstract void LoadInput(object obj);
+    }
+
+    public partial class TransformChain
+    {
+        public int Count { get { throw null; } }
+
+        public Transform this[int index] { get { throw null; } }
+
+        public void Add(Transform transform) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class XmlDecryptionTransform : Transform
+    {
+        public EncryptedXml EncryptedXml { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public void AddExceptUri(string uri) { }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        protected virtual bool IsTargetElement(System.Xml.XmlElement? inputElement, string idValue) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigBase64Transform : Transform
+    {
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigC14NTransform : Transform
+    {
+        public XmlDsigC14NTransform() { }
+
+        public XmlDsigC14NTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public override byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigC14NWithCommentsTransform : XmlDsigC14NTransform
+    {
+    }
+
+    public partial class XmlDsigEnvelopedSignatureTransform : Transform
+    {
+        public XmlDsigEnvelopedSignatureTransform() { }
+
+        public XmlDsigEnvelopedSignatureTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigExcC14NTransform : Transform
+    {
+        public XmlDsigExcC14NTransform() { }
+
+        public XmlDsigExcC14NTransform(bool includeComments, string? inclusiveNamespacesPrefixList) { }
+
+        public XmlDsigExcC14NTransform(bool includeComments) { }
+
+        public XmlDsigExcC14NTransform(string inclusiveNamespacesPrefixList) { }
+
+        public string? InclusiveNamespacesPrefixList { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public override byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigExcC14NWithCommentsTransform : XmlDsigExcC14NTransform
+    {
+        public XmlDsigExcC14NWithCommentsTransform() { }
+
+        public XmlDsigExcC14NWithCommentsTransform(string inclusiveNamespacesPrefixList) { }
+    }
+
+    public partial class XmlDsigXPathTransform : Transform
+    {
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+    public partial class XmlDsigXsltTransform : Transform
+    {
+        public XmlDsigXsltTransform() { }
+
+        public XmlDsigXsltTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    [Diagnostics.CodeAnalysis.RequiresDynamicCode("XmlDsigXsltTransform uses XslCompiledTransform which requires dynamic code.")]
+    [Diagnostics.CodeAnalysis.RequiresUnreferencedCode("The algorithm implementations referenced in the XML payload might be removed. Ensure the required algorithm implementations are preserved in your application.")]
+    public partial class XmlLicenseTransform : Transform
+    {
+        public IRelDecryptor? Decryptor { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.xml/8.0.4/lib/netstandard2.0/System.Security.Cryptography.Xml.cs
+++ b/src/referencePackages/src/system.security.cryptography.xml/8.0.4/lib/netstandard2.0/System.Security.Cryptography.Xml.cs
@@ -1,0 +1,900 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+// ------------------------------------------------------------------------------
+// Changes to this file must follow the http://aka.ms/api-review process.
+// ------------------------------------------------------------------------------
+[assembly: System.Runtime.CompilerServices.CompilationRelaxations(8)]
+[assembly: System.Runtime.CompilerServices.RuntimeCompatibility(WrapNonExceptionThrows = true)]
+[assembly: System.Diagnostics.Debuggable(System.Diagnostics.DebuggableAttribute.DebuggingModes.IgnoreSymbolStoreSequencePoints)]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName = ".NET Standard 2.0")]
+[assembly: System.Reflection.AssemblyMetadata("Serviceable", "True")]
+[assembly: System.Reflection.AssemblyMetadata("PreferInbox", "True")]
+[assembly: System.Reflection.AssemblyDefaultAlias("System.Security.Cryptography.Xml")]
+[assembly: System.Resources.NeutralResourcesLanguage("en-US")]
+[assembly: System.CLSCompliant(true)]
+[assembly: System.Reflection.AssemblyMetadata("IsTrimmable", "True")]
+[assembly: System.Runtime.InteropServices.DefaultDllImportSearchPaths(System.Runtime.InteropServices.DllImportSearchPath.AssemblyDirectory | System.Runtime.InteropServices.DllImportSearchPath.System32)]
+[assembly: System.Reflection.AssemblyCompany("Microsoft Corporation")]
+[assembly: System.Reflection.AssemblyCopyright("© Microsoft Corporation. All rights reserved.")]
+[assembly: System.Reflection.AssemblyDescription("Provides classes to support the creation and validation of XML digital signatures. The classes in this namespace implement the World Wide Web Consortium Recommendation, \"XML-Signature Syntax and Processing\", described at http://www.w3.org/TR/xmldsig-core/.\r\n\r\nCommonly Used Types:\r\nSystem.Security.Cryptography.Xml.CipherData\r\nSystem.Security.Cryptography.Xml.CipherReference\r\nSystem.Security.Cryptography.Xml.DataObject\r\nSystem.Security.Cryptography.Xml.DataReference\r\nSystem.Security.Cryptography.Xml.DSAKeyValue\r\nSystem.Security.Cryptography.Xml.EncryptedData\r\nSystem.Security.Cryptography.Xml.EncryptedKey\r\nSystem.Security.Cryptography.Xml.EncryptedReference\r\nSystem.Security.Cryptography.Xml.EncryptedType\r\nSystem.Security.Cryptography.Xml.EncryptedXml\r\nSystem.Security.Cryptography.Xml.EncryptionMethod\r\nSystem.Security.Cryptography.Xml.EncryptionProperty\r\nSystem.Security.Cryptography.Xml.EncryptionPropertyCollection\r\nSystem.Security.Cryptography.Xml.KeyInfo\r\nSystem.Security.Cryptography.Xml.KeyInfoClause\r\nSystem.Security.Cryptography.Xml.KeyInfoEncryptedKey\r\nSystem.Security.Cryptography.Xml.KeyInfoName\r\nSystem.Security.Cryptography.Xml.KeyInfoNode\r\nSystem.Security.Cryptography.Xml.KeyInfoRetrievalMethod\r\nSystem.Security.Cryptography.Xml.KeyInfoX509Data\r\nSystem.Security.Cryptography.Xml.KeyReference\r\nSystem.Security.Cryptography.Xml.Reference\r\nSystem.Security.Cryptography.Xml.ReferenceList\r\nSystem.Security.Cryptography.Xml.RSAKeyValue\r\nSystem.Security.Cryptography.Xml.Signature\r\nSystem.Security.Cryptography.Xml.SignedInfo\r\nSystem.Security.Cryptography.Xml.SignedXml\r\nSystem.Security.Cryptography.Xml.Transform\r\nSystem.Security.Cryptography.Xml.TransformChain\r\nSystem.Security.Cryptography.Xml.XmlDecryptionTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigBase64Transform\r\nSystem.Security.Cryptography.Xml.XmlDsigC14NTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigC14NWithCommentsTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigEnvelopedSignatureTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigExcC14NTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigExcC14NWithCommentsTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigXPathTransform\r\nSystem.Security.Cryptography.Xml.XmlDsigXsltTransform\r\nSystem.Security.Cryptography.Xml.XmlLicenseTransform")]
+[assembly: System.Reflection.AssemblyFileVersion("8.0.2926.32403")]
+[assembly: System.Reflection.AssemblyInformationalVersion("8.0.29+18fd75c847399745c43b5970fec840ba71064e80")]
+[assembly: System.Reflection.AssemblyProduct("Microsoft® .NET")]
+[assembly: System.Reflection.AssemblyTitle("System.Security.Cryptography.Xml")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/dotnet/runtime")]
+[assembly: System.Reflection.AssemblyVersionAttribute("8.0.0.0")]
+[assembly: System.Runtime.CompilerServices.ReferenceAssembly]
+[assembly: System.Reflection.AssemblyFlagsAttribute((System.Reflection.AssemblyNameFlags)0x70)]
+namespace System.Security.Cryptography.Xml
+{
+    public sealed partial class CipherData
+    {
+        public CipherData() { }
+
+        public CipherData(byte[] cipherValue) { }
+
+        public CipherData(CipherReference cipherReference) { }
+
+        public CipherReference? CipherReference { get { throw null; } set { } }
+
+        public byte[]? CipherValue { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class CipherReference : EncryptedReference
+    {
+        public CipherReference() { }
+
+        public CipherReference(string uri, TransformChain transformChain) { }
+
+        public CipherReference(string uri) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class CryptoSignedXmlRecursionException : System.Xml.XmlException
+    {
+        public CryptoSignedXmlRecursionException() { }
+
+        protected CryptoSignedXmlRecursionException(Runtime.Serialization.SerializationInfo info, Runtime.Serialization.StreamingContext context) { }
+
+        public CryptoSignedXmlRecursionException(string message, Exception inner) { }
+
+        public CryptoSignedXmlRecursionException(string message) { }
+    }
+
+    public partial class DataObject
+    {
+        public DataObject() { }
+
+        public DataObject(string id, string mimeType, string encoding, System.Xml.XmlElement data) { }
+
+        public System.Xml.XmlNodeList Data { get { throw null; } set { } }
+
+        public string? Encoding { get { throw null; } set { } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public string? MimeType { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class DataReference : EncryptedReference
+    {
+        public DataReference() { }
+
+        public DataReference(string uri, TransformChain transformChain) { }
+
+        public DataReference(string uri) { }
+    }
+
+    public partial class DSAKeyValue : KeyInfoClause
+    {
+        public DSAKeyValue() { }
+
+        public DSAKeyValue(DSA key) { }
+
+        public DSA Key { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptedData : EncryptedType
+    {
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptedKey : EncryptedType
+    {
+        public string? CarriedKeyName { get { throw null; } set { } }
+
+        public string Recipient { get { throw null; } set { } }
+
+        public ReferenceList ReferenceList { get { throw null; } }
+
+        public void AddReference(DataReference dataReference) { }
+
+        public void AddReference(KeyReference keyReference) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class EncryptedReference
+    {
+        protected EncryptedReference() { }
+
+        protected EncryptedReference(string uri, TransformChain transformChain) { }
+
+        protected EncryptedReference(string uri) { }
+
+        protected internal bool CacheValid { get { throw null; } }
+
+        protected string? ReferenceType { get { throw null; } set { } }
+
+        public TransformChain TransformChain { get { throw null; } set { } }
+
+        public string Uri { get { throw null; } set { } }
+
+        public void AddTransform(Transform transform) { }
+
+        public virtual System.Xml.XmlElement GetXml() { throw null; }
+
+        public virtual void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class EncryptedType
+    {
+        public virtual CipherData CipherData { get { throw null; } set { } }
+
+        public virtual string? Encoding { get { throw null; } set { } }
+
+        public virtual EncryptionMethod? EncryptionMethod { get { throw null; } set { } }
+
+        public virtual EncryptionPropertyCollection EncryptionProperties { get { throw null; } }
+
+        public virtual string? Id { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public virtual string? MimeType { get { throw null; } set { } }
+
+        public virtual string? Type { get { throw null; } set { } }
+
+        public void AddProperty(EncryptionProperty ep) { }
+
+        public abstract System.Xml.XmlElement GetXml();
+        public abstract void LoadXml(System.Xml.XmlElement value);
+    }
+
+    public partial class EncryptedXml
+    {
+        public const string XmlEncAES128KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes128";
+        public const string XmlEncAES128Url = "http://www.w3.org/2001/04/xmlenc#aes128-cbc";
+        public const string XmlEncAES192KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes192";
+        public const string XmlEncAES192Url = "http://www.w3.org/2001/04/xmlenc#aes192-cbc";
+        public const string XmlEncAES256KeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-aes256";
+        public const string XmlEncAES256Url = "http://www.w3.org/2001/04/xmlenc#aes256-cbc";
+        public const string XmlEncDESUrl = "http://www.w3.org/2001/04/xmlenc#des-cbc";
+        public const string XmlEncElementContentUrl = "http://www.w3.org/2001/04/xmlenc#Content";
+        public const string XmlEncElementUrl = "http://www.w3.org/2001/04/xmlenc#Element";
+        public const string XmlEncEncryptedKeyUrl = "http://www.w3.org/2001/04/xmlenc#EncryptedKey";
+        public const string XmlEncNamespaceUrl = "http://www.w3.org/2001/04/xmlenc#";
+        public const string XmlEncRSA15Url = "http://www.w3.org/2001/04/xmlenc#rsa-1_5";
+        public const string XmlEncRSAOAEPUrl = "http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p";
+        public const string XmlEncSHA256Url = "http://www.w3.org/2001/04/xmlenc#sha256";
+        public const string XmlEncSHA512Url = "http://www.w3.org/2001/04/xmlenc#sha512";
+        public const string XmlEncTripleDESKeyWrapUrl = "http://www.w3.org/2001/04/xmlenc#kw-tripledes";
+        public const string XmlEncTripleDESUrl = "http://www.w3.org/2001/04/xmlenc#tripledes-cbc";
+        public EncryptedXml() { }
+
+        public EncryptedXml(System.Xml.XmlDocument document, Policy.Evidence? evidence) { }
+
+        public EncryptedXml(System.Xml.XmlDocument document) { }
+
+        public Policy.Evidence? DocumentEvidence { get { throw null; } set { } }
+
+        public Text.Encoding Encoding { get { throw null; } set { } }
+
+        public CipherMode Mode { get { throw null; } set { } }
+
+        public PaddingMode Padding { get { throw null; } set { } }
+
+        public string Recipient { get { throw null; } set { } }
+
+        public System.Xml.XmlResolver? Resolver { get { throw null; } set { } }
+
+        public int XmlDSigSearchDepth { get { throw null; } set { } }
+
+        public void AddKeyNameMapping(string keyName, object keyObject) { }
+
+        public void ClearKeyNameMappings() { }
+
+        public byte[] DecryptData(EncryptedData encryptedData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        public void DecryptDocument() { }
+
+        public virtual byte[]? DecryptEncryptedKey(EncryptedKey encryptedKey) { throw null; }
+
+        public static byte[] DecryptKey(byte[] keyData, RSA rsa, bool useOAEP) { throw null; }
+
+        public static byte[] DecryptKey(byte[] keyData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        public EncryptedData Encrypt(System.Xml.XmlElement inputElement, X509Certificates.X509Certificate2 certificate) { throw null; }
+
+        public EncryptedData Encrypt(System.Xml.XmlElement inputElement, string keyName) { throw null; }
+
+        public byte[] EncryptData(byte[] plaintext, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        public byte[] EncryptData(System.Xml.XmlElement inputElement, SymmetricAlgorithm symmetricAlgorithm, bool content) { throw null; }
+
+        public static byte[] EncryptKey(byte[] keyData, RSA rsa, bool useOAEP) { throw null; }
+
+        public static byte[] EncryptKey(byte[] keyData, SymmetricAlgorithm symmetricAlgorithm) { throw null; }
+
+        public virtual byte[] GetDecryptionIV(EncryptedData encryptedData, string? symmetricAlgorithmUri) { throw null; }
+
+        public virtual SymmetricAlgorithm? GetDecryptionKey(EncryptedData encryptedData, string? symmetricAlgorithmUri) { throw null; }
+
+        public virtual System.Xml.XmlElement? GetIdElement(System.Xml.XmlDocument document, string idValue) { throw null; }
+
+        public void ReplaceData(System.Xml.XmlElement inputElement, byte[] decryptedData) { }
+
+        public static void ReplaceElement(System.Xml.XmlElement inputElement, EncryptedData encryptedData, bool content) { }
+    }
+
+    public partial class EncryptionMethod
+    {
+        public EncryptionMethod() { }
+
+        public EncryptionMethod(string? algorithm) { }
+
+        public string? KeyAlgorithm { get { throw null; } set { } }
+
+        public int KeySize { get { throw null; } set { } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptionProperty
+    {
+        public EncryptionProperty() { }
+
+        public EncryptionProperty(System.Xml.XmlElement elementProperty) { }
+
+        public string? Id { get { throw null; } }
+
+        public System.Xml.XmlElement? PropertyElement { get { throw null; } set { } }
+
+        public string? Target { get { throw null; } }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class EncryptionPropertyCollection : Collections.IList, Collections.ICollection, Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public bool IsFixedSize { get { throw null; } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        [System.Runtime.CompilerServices.IndexerName("ItemOf")]
+        public EncryptionProperty this[int index] { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        object? Collections.IList.this[int index] { get { throw null; } set { } }
+
+        public int Add(EncryptionProperty value) { throw null; }
+
+        public void Clear() { }
+
+        public bool Contains(EncryptionProperty value) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public void CopyTo(EncryptionProperty[] array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public int IndexOf(EncryptionProperty value) { throw null; }
+
+        public void Insert(int index, EncryptionProperty value) { }
+
+        public EncryptionProperty Item(int index) { throw null; }
+
+        public void Remove(EncryptionProperty value) { }
+
+        public void RemoveAt(int index) { }
+
+        int Collections.IList.Add(object value) { throw null; }
+
+        bool Collections.IList.Contains(object value) { throw null; }
+
+        int Collections.IList.IndexOf(object value) { throw null; }
+
+        void Collections.IList.Insert(int index, object value) { }
+
+        void Collections.IList.Remove(object value) { }
+    }
+
+    public partial interface IRelDecryptor
+    {
+        IO.Stream Decrypt(EncryptionMethod encryptionMethod, KeyInfo keyInfo, IO.Stream toDecrypt);
+    }
+
+    public partial class KeyInfo : Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public void AddClause(KeyInfoClause clause) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public Collections.IEnumerator GetEnumerator(Type requestedObjectType) { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class KeyInfoClause
+    {
+        public abstract System.Xml.XmlElement GetXml();
+        public abstract void LoadXml(System.Xml.XmlElement element);
+    }
+
+    public partial class KeyInfoEncryptedKey : KeyInfoClause
+    {
+        public KeyInfoEncryptedKey() { }
+
+        public KeyInfoEncryptedKey(EncryptedKey encryptedKey) { }
+
+        public EncryptedKey? EncryptedKey { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoName : KeyInfoClause
+    {
+        public KeyInfoName() { }
+
+        public KeyInfoName(string? keyName) { }
+
+        public string? Value { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoNode : KeyInfoClause
+    {
+        public KeyInfoNode() { }
+
+        public KeyInfoNode(System.Xml.XmlElement node) { }
+
+        public System.Xml.XmlElement? Value { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoRetrievalMethod : KeyInfoClause
+    {
+        public KeyInfoRetrievalMethod() { }
+
+        public KeyInfoRetrievalMethod(string strUri, string typeName) { }
+
+        public KeyInfoRetrievalMethod(string? strUri) { }
+
+        public string? Type { get { throw null; } set { } }
+
+        public string? Uri { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class KeyInfoX509Data : KeyInfoClause
+    {
+        public KeyInfoX509Data() { }
+
+        public KeyInfoX509Data(byte[] rgbCert) { }
+
+        public KeyInfoX509Data(X509Certificates.X509Certificate cert, X509Certificates.X509IncludeOption includeOption) { }
+
+        public KeyInfoX509Data(X509Certificates.X509Certificate cert) { }
+
+        public Collections.ArrayList? Certificates { get { throw null; } }
+
+        public byte[]? CRL { get { throw null; } set { } }
+
+        public Collections.ArrayList? IssuerSerials { get { throw null; } }
+
+        public Collections.ArrayList? SubjectKeyIds { get { throw null; } }
+
+        public Collections.ArrayList? SubjectNames { get { throw null; } }
+
+        public void AddCertificate(X509Certificates.X509Certificate certificate) { }
+
+        public void AddIssuerSerial(string issuerName, string serialNumber) { }
+
+        public void AddSubjectKeyId(byte[] subjectKeyId) { }
+
+        public void AddSubjectKeyId(string subjectKeyId) { }
+
+        public void AddSubjectName(string subjectName) { }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement element) { }
+    }
+
+    public sealed partial class KeyReference : EncryptedReference
+    {
+        public KeyReference() { }
+
+        public KeyReference(string uri, TransformChain transformChain) { }
+
+        public KeyReference(string uri) { }
+    }
+
+    public partial class Reference
+    {
+        public Reference() { }
+
+        public Reference(IO.Stream stream) { }
+
+        public Reference(string? uri) { }
+
+        public string DigestMethod { get { throw null; } set { } }
+
+        public byte[]? DigestValue { get { throw null; } set { } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public TransformChain TransformChain { get { throw null; } set { } }
+
+        public string? Type { get { throw null; } set { } }
+
+        public string? Uri { get { throw null; } set { } }
+
+        public void AddTransform(Transform transform) { }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public sealed partial class ReferenceList : Collections.IList, Collections.ICollection, Collections.IEnumerable
+    {
+        public int Count { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        [System.Runtime.CompilerServices.IndexerName("ItemOf")]
+        public EncryptedReference this[int index] { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        bool Collections.IList.IsFixedSize { get { throw null; } }
+
+        bool Collections.IList.IsReadOnly { get { throw null; } }
+
+        object? Collections.IList.this[int index] { get { throw null; } set { } }
+
+        public int Add(object? value) { throw null; }
+
+        public void Clear() { }
+
+        public bool Contains(object? value) { throw null; }
+
+        public void CopyTo(Array array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public int IndexOf(object? value) { throw null; }
+
+        public void Insert(int index, object? value) { }
+
+        public EncryptedReference? Item(int index) { throw null; }
+
+        public void Remove(object? value) { }
+
+        public void RemoveAt(int index) { }
+    }
+
+    public partial class RSAKeyValue : KeyInfoClause
+    {
+        public RSAKeyValue() { }
+
+        public RSAKeyValue(RSA key) { }
+
+        public RSA Key { get { throw null; } set { } }
+
+        public override System.Xml.XmlElement GetXml() { throw null; }
+
+        public override void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class Signature
+    {
+        public string? Id { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public Collections.IList ObjectList { get { throw null; } set { } }
+
+        public byte[]? SignatureValue { get { throw null; } set { } }
+
+        public SignedInfo? SignedInfo { get { throw null; } set { } }
+
+        public void AddObject(DataObject dataObject) { }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class SignedInfo : Collections.ICollection, Collections.IEnumerable
+    {
+        public string CanonicalizationMethod { get { throw null; } set { } }
+
+        public Transform CanonicalizationMethodObject { get { throw null; } }
+
+        public int Count { get { throw null; } }
+
+        public string? Id { get { throw null; } set { } }
+
+        public bool IsReadOnly { get { throw null; } }
+
+        public bool IsSynchronized { get { throw null; } }
+
+        public Collections.ArrayList References { get { throw null; } }
+
+        public string? SignatureLength { get { throw null; } set { } }
+
+        public string? SignatureMethod { get { throw null; } set { } }
+
+        public object SyncRoot { get { throw null; } }
+
+        public void AddReference(Reference reference) { }
+
+        public void CopyTo(Array array, int index) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public partial class SignedXml
+    {
+        protected Signature m_signature;
+        protected string? m_strSigningKeyName;
+        public const string XmlDecryptionTransformUrl = "http://www.w3.org/2002/07/decrypt#XML";
+        public const string XmlDsigBase64TransformUrl = "http://www.w3.org/2000/09/xmldsig#base64";
+        public const string XmlDsigC14NTransformUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+        public const string XmlDsigC14NWithCommentsTransformUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
+        public const string XmlDsigCanonicalizationUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315";
+        public const string XmlDsigCanonicalizationWithCommentsUrl = "http://www.w3.org/TR/2001/REC-xml-c14n-20010315#WithComments";
+        public const string XmlDsigDSAUrl = "http://www.w3.org/2000/09/xmldsig#dsa-sha1";
+        public const string XmlDsigEnvelopedSignatureTransformUrl = "http://www.w3.org/2000/09/xmldsig#enveloped-signature";
+        public const string XmlDsigExcC14NTransformUrl = "http://www.w3.org/2001/10/xml-exc-c14n#";
+        public const string XmlDsigExcC14NWithCommentsTransformUrl = "http://www.w3.org/2001/10/xml-exc-c14n#WithComments";
+        public const string XmlDsigHMACSHA1Url = "http://www.w3.org/2000/09/xmldsig#hmac-sha1";
+        public const string XmlDsigMinimalCanonicalizationUrl = "http://www.w3.org/2000/09/xmldsig#minimal";
+        public const string XmlDsigNamespaceUrl = "http://www.w3.org/2000/09/xmldsig#";
+        public const string XmlDsigRSASHA1Url = "http://www.w3.org/2000/09/xmldsig#rsa-sha1";
+        public const string XmlDsigRSASHA256Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha256";
+        public const string XmlDsigRSASHA384Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha384";
+        public const string XmlDsigRSASHA512Url = "http://www.w3.org/2001/04/xmldsig-more#rsa-sha512";
+        public const string XmlDsigSHA1Url = "http://www.w3.org/2000/09/xmldsig#sha1";
+        public const string XmlDsigSHA256Url = "http://www.w3.org/2001/04/xmlenc#sha256";
+        public const string XmlDsigSHA384Url = "http://www.w3.org/2001/04/xmldsig-more#sha384";
+        public const string XmlDsigSHA512Url = "http://www.w3.org/2001/04/xmlenc#sha512";
+        public const string XmlDsigXPathTransformUrl = "http://www.w3.org/TR/1999/REC-xpath-19991116";
+        public const string XmlDsigXsltTransformUrl = "http://www.w3.org/TR/1999/REC-xslt-19991116";
+        public const string XmlLicenseTransformUrl = "urn:mpeg:mpeg21:2003:01-REL-R-NS:licenseTransform";
+        public SignedXml() { }
+
+        public SignedXml(System.Xml.XmlDocument document) { }
+
+        public SignedXml(System.Xml.XmlElement elem) { }
+
+        public EncryptedXml EncryptedXml { get { throw null; } set { } }
+
+        public KeyInfo KeyInfo { get { throw null; } set { } }
+
+        public System.Xml.XmlResolver Resolver { set { } }
+
+        public Collections.ObjectModel.Collection<string> SafeCanonicalizationMethods { get { throw null; } }
+
+        public Signature Signature { get { throw null; } }
+
+        public Func<SignedXml, bool> SignatureFormatValidator { get { throw null; } set { } }
+
+        public string? SignatureLength { get { throw null; } }
+
+        public string? SignatureMethod { get { throw null; } }
+
+        public byte[]? SignatureValue { get { throw null; } }
+
+        public SignedInfo? SignedInfo { get { throw null; } }
+
+        public AsymmetricAlgorithm? SigningKey { get { throw null; } set { } }
+
+        public string? SigningKeyName { get { throw null; } set { } }
+
+        public void AddObject(DataObject dataObject) { }
+
+        public void AddReference(Reference reference) { }
+
+        public bool CheckSignature() { throw null; }
+
+        public bool CheckSignature(AsymmetricAlgorithm key) { throw null; }
+
+        public bool CheckSignature(KeyedHashAlgorithm macAlg) { throw null; }
+
+        public bool CheckSignature(X509Certificates.X509Certificate2 certificate, bool verifySignatureOnly) { throw null; }
+
+        public bool CheckSignatureReturningKey(out AsymmetricAlgorithm? signingKey) { throw null; }
+
+        public void ComputeSignature() { }
+
+        public void ComputeSignature(KeyedHashAlgorithm macAlg) { }
+
+        public virtual System.Xml.XmlElement? GetIdElement(System.Xml.XmlDocument? document, string idValue) { throw null; }
+
+        protected virtual AsymmetricAlgorithm? GetPublicKey() { throw null; }
+
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public void LoadXml(System.Xml.XmlElement value) { }
+    }
+
+    public abstract partial class Transform
+    {
+        public string? Algorithm { get { throw null; } set { } }
+
+        public System.Xml.XmlElement? Context { get { throw null; } set { } }
+
+        public abstract Type[] InputTypes { get; }
+        public abstract Type[] OutputTypes { get; }
+
+        public Collections.Hashtable PropagatedNamespaces { get { throw null; } }
+
+        public System.Xml.XmlResolver? Resolver { set { } }
+
+        public virtual byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected abstract System.Xml.XmlNodeList? GetInnerXml();
+        public abstract object GetOutput();
+        public abstract object GetOutput(Type type);
+        public System.Xml.XmlElement GetXml() { throw null; }
+
+        public abstract void LoadInnerXml(System.Xml.XmlNodeList nodeList);
+        public abstract void LoadInput(object obj);
+    }
+
+    public partial class TransformChain
+    {
+        public int Count { get { throw null; } }
+
+        public Transform this[int index] { get { throw null; } }
+
+        public void Add(Transform transform) { }
+
+        public Collections.IEnumerator GetEnumerator() { throw null; }
+    }
+
+    public partial class XmlDecryptionTransform : Transform
+    {
+        public EncryptedXml EncryptedXml { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public void AddExceptUri(string uri) { }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        protected virtual bool IsTargetElement(System.Xml.XmlElement? inputElement, string idValue) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigBase64Transform : Transform
+    {
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigC14NTransform : Transform
+    {
+        public XmlDsigC14NTransform() { }
+
+        public XmlDsigC14NTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public override byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigC14NWithCommentsTransform : XmlDsigC14NTransform
+    {
+    }
+
+    public partial class XmlDsigEnvelopedSignatureTransform : Transform
+    {
+        public XmlDsigEnvelopedSignatureTransform() { }
+
+        public XmlDsigEnvelopedSignatureTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigExcC14NTransform : Transform
+    {
+        public XmlDsigExcC14NTransform() { }
+
+        public XmlDsigExcC14NTransform(bool includeComments, string? inclusiveNamespacesPrefixList) { }
+
+        public XmlDsigExcC14NTransform(bool includeComments) { }
+
+        public XmlDsigExcC14NTransform(string inclusiveNamespacesPrefixList) { }
+
+        public string? InclusiveNamespacesPrefixList { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        public override byte[] GetDigestedOutput(HashAlgorithm hash) { throw null; }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigExcC14NWithCommentsTransform : XmlDsigExcC14NTransform
+    {
+        public XmlDsigExcC14NWithCommentsTransform() { }
+
+        public XmlDsigExcC14NWithCommentsTransform(string inclusiveNamespacesPrefixList) { }
+    }
+
+    public partial class XmlDsigXPathTransform : Transform
+    {
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlDsigXsltTransform : Transform
+    {
+        public XmlDsigXsltTransform() { }
+
+        public XmlDsigXsltTransform(bool includeComments) { }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+
+    public partial class XmlLicenseTransform : Transform
+    {
+        public IRelDecryptor? Decryptor { get { throw null; } set { } }
+
+        public override Type[] InputTypes { get { throw null; } }
+
+        public override Type[] OutputTypes { get { throw null; } }
+
+        protected override System.Xml.XmlNodeList? GetInnerXml() { throw null; }
+
+        public override object GetOutput() { throw null; }
+
+        public override object GetOutput(Type type) { throw null; }
+
+        public override void LoadInnerXml(System.Xml.XmlNodeList nodeList) { }
+
+        public override void LoadInput(object obj) { }
+    }
+}

--- a/src/referencePackages/src/system.security.cryptography.xml/8.0.4/system.security.cryptography.xml.nuspec
+++ b/src/referencePackages/src/system.security.cryptography.xml/8.0.4/system.security.cryptography.xml.nuspec
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>System.Security.Cryptography.Xml</id>
+    <version>8.0.4</version>
+    <authors>Microsoft</authors>
+    <license type="expression">MIT</license>
+    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
+    <projectUrl>https://dot.net/</projectUrl>
+    <description>Provides classes to support the creation and validation of XML digital signatures. The classes in this namespace implement the World Wide Web Consortium Recommendation, "XML-Signature Syntax and Processing", described at http://www.w3.org/TR/xmldsig-core/.
+
+Commonly Used Types:
+System.Security.Cryptography.Xml.CipherData
+System.Security.Cryptography.Xml.CipherReference
+System.Security.Cryptography.Xml.DataObject
+System.Security.Cryptography.Xml.DataReference
+System.Security.Cryptography.Xml.DSAKeyValue
+System.Security.Cryptography.Xml.EncryptedData
+System.Security.Cryptography.Xml.EncryptedKey
+System.Security.Cryptography.Xml.EncryptedReference
+System.Security.Cryptography.Xml.EncryptedType
+System.Security.Cryptography.Xml.EncryptedXml
+System.Security.Cryptography.Xml.EncryptionMethod
+System.Security.Cryptography.Xml.EncryptionProperty
+System.Security.Cryptography.Xml.EncryptionPropertyCollection
+System.Security.Cryptography.Xml.KeyInfo
+System.Security.Cryptography.Xml.KeyInfoClause
+System.Security.Cryptography.Xml.KeyInfoEncryptedKey
+System.Security.Cryptography.Xml.KeyInfoName
+System.Security.Cryptography.Xml.KeyInfoNode
+System.Security.Cryptography.Xml.KeyInfoRetrievalMethod
+System.Security.Cryptography.Xml.KeyInfoX509Data
+System.Security.Cryptography.Xml.KeyReference
+System.Security.Cryptography.Xml.Reference
+System.Security.Cryptography.Xml.ReferenceList
+System.Security.Cryptography.Xml.RSAKeyValue
+System.Security.Cryptography.Xml.Signature
+System.Security.Cryptography.Xml.SignedInfo
+System.Security.Cryptography.Xml.SignedXml
+System.Security.Cryptography.Xml.Transform
+System.Security.Cryptography.Xml.TransformChain
+System.Security.Cryptography.Xml.XmlDecryptionTransform
+System.Security.Cryptography.Xml.XmlDsigBase64Transform
+System.Security.Cryptography.Xml.XmlDsigC14NTransform
+System.Security.Cryptography.Xml.XmlDsigC14NWithCommentsTransform
+System.Security.Cryptography.Xml.XmlDsigEnvelopedSignatureTransform
+System.Security.Cryptography.Xml.XmlDsigExcC14NTransform
+System.Security.Cryptography.Xml.XmlDsigExcC14NWithCommentsTransform
+System.Security.Cryptography.Xml.XmlDsigXPathTransform
+System.Security.Cryptography.Xml.XmlDsigXsltTransform
+System.Security.Cryptography.Xml.XmlLicenseTransform</description>
+    <releaseNotes>https://go.microsoft.com/fwlink/?LinkID=799421</releaseNotes>
+    <copyright>© Microsoft Corporation. All rights reserved.</copyright>
+    <serviceable>true</serviceable>
+    <repository type="git" url="https://github.com/dotnet/runtime" commit="18fd75c847399745c43b5970fec840ba71064e80" />
+    <dependencies>
+      <group targetFramework="net6.0">
+        <dependency id="System.Security.Cryptography.Pkcs" version="8.0.1" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net7.0">
+        <dependency id="System.Security.Cryptography.Pkcs" version="8.0.1" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework="net8.0">
+        <dependency id="System.Security.Cryptography.Pkcs" version="8.0.1" exclude="Build,Analyzers" />
+      </group>
+      <group targetFramework=".NETStandard2.0">
+        <dependency id="System.Security.Cryptography.Pkcs" version="8.0.1" exclude="Build,Analyzers" />
+        <dependency id="System.Memory" version="4.5.5" exclude="Build,Analyzers" />
+        <dependency id="System.Security.AccessControl" version="6.0.0" exclude="Build,Analyzers" />
+      </group>
+    </dependencies>
+  </metadata>
+</package>


### PR DESCRIPTION
Adds the source-built reference package for System.Security.Cryptography.Xml 8.0.4.

- Uses the existing source-built System.Security.Cryptography.Pkcs 8.0.1 dependency; no additional System.Security.Cryptography packages are required.
- Carries forward the IndexerName metadata fix from #1676.
- Registers the package as a DependencyPackageProject.

Validation:
- Targeted source-build completed successfully and produced System.Security.Cryptography.Xml.8.0.4.nupkg for net6.0, net7.0, net8.0, and netstandard2.0.
- The full inner source-build completed successfully. The final prebuilt-baseline check on macOS reports the host-specific runtime.osx-arm64 ILAsm/ILDAsm packages; product source-build is supported on Linux.
