### PR TITLE
Document current-version reference package restriction

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,6 +10,11 @@ All general documentation is maintained in the [README.md](../README.md) to avoi
 - **NEVER** modify files inside `src/externalPackages/src/` (these are git submodules)
 - **NEVER** delete or recreate `Customizations.props` or `Customizations.cs` files
 - **NEVER** suggest adding preview/RC packages
+- **NEVER** add or generate `N.x` reference packages or current-TFM targeting
+  packages for a `release/N.0` branch or the corresponding development branch.
+  Source-build-assets may cover only older .NET versions; resolve current-version
+  dependencies through the current source-build dependency graph or
+  previously-source-built (PSB) packages.
 - **NEVER** ignore build failures in `./build.sh -sb`
 - **NEVER** hand-author `.nuspec` files for reference or text-only packages — they are
   no longer present in the source tree. Per-package metadata (description, license,

--- a/README.md
+++ b/README.md
@@ -240,6 +240,16 @@ appropriate to add these types of package as allowed prebuilt via the `eng/Sourc
 file. See the [Eliminating pre-builts documentation](https://github.com/dotnet/source-build/blob/main/Documentation/eliminating-pre-builts.md)
 for detailed guidance.
 
+> **Important:** For a .NET `N` product release, reference packages in this repository must target only
+older .NET versions. Do not add `N.x` reference packages or current-TFM targeting packages to
+`release/N.0` or the corresponding development branch. A generated current-major reference package
+generally targets `netN.0` and depends on `Microsoft.NETCore.App.Ref` `N.0`. Source-build-assets is
+part of the bootstrap layer: it builds before runtime, while runtime depends on source-build-assets.
+Depending on the current product targeting pack would invert that dependency, create a build cycle,
+and undermine N-1 bootstrapping. Resolve current-version dependencies through the current
+source-build dependency graph or, when necessary to break a legitimate bootstrap cycle, use
+previously-source-built (PSB) packages instead of current-major reference-package API stubs.
+
 ``` bash
 ./generate.sh --package system.buffers,4.5.1
 ```


### PR DESCRIPTION
Source-build-assets must not depend on the current product targeting pack because it is part of the bootstrap layer that builds before runtime. Doing so would invert the runtime dependency and undermine N-1 bootstrapping.

Document that `release/N.0` and its corresponding development branch may contain reference packages only for older .NET versions. The guidance directs current-version dependencies through the source-build dependency graph or previously-source-built packages, and adds the same restriction to the Copilot agent safety rules.