### PR TITLE
Disable CodeQL for external and reference packages

### DIFF
--- a/CodeQL.yml
+++ b/CodeQL.yml
@@ -1,3 +1,4 @@
 path_classifiers:
   library:
-    - "src/externalPackages/src/azure-activedirectory-identitymodel-extensions-for-dotnet/**"
+    - "src/externalPackages/**"
+    - "src/referencePackages/**"


### PR DESCRIPTION
External and reference package sources are imported or generated rather than maintained as production implementations in this repository, so CodeQL findings from those paths are not actionable.

Classify all content under `src/externalPackages` and `src/referencePackages` as library code, replacing the package-specific external exclusion with category-wide coverage.